### PR TITLE
[Chore] hilt custom plugin 생성

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
     alias(libs.plugins.depromeet.team5.application)
     alias(libs.plugins.depromeet.team5.application.compose)
-    alias(libs.plugins.hilt)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.depromeet.team5.hilt)
 }
 
 android {
@@ -31,9 +30,6 @@ android {
 dependencies {
 
     implementation(libs.androidx.core.ktx)
-
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.android.compiler)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -54,7 +54,7 @@ gradlePlugin {
 
         register("Hilt") {
             id = libs.plugins.depromeet.team5.hilt.get().pluginId
-            implementationClass = "HiltConventionPlugin"
+            implementationClass = "AndroidHiltConventionPlugin"
         }
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -51,5 +51,10 @@ gradlePlugin {
             id = libs.plugins.depromeet.team5.library.compose.get().pluginId
             implementationClass = "AndroidLibraryComposeConventionPlugin"
         }
+
+        register("Hilt") {
+            id = libs.plugins.depromeet.team5.hilt.get().pluginId
+            implementationClass = "HiltConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -1,28 +1,20 @@
+import com.depromeet.team5.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 
 class AndroidHiltConventionPlugin : Plugin<Project> {
+
     override fun apply(target: Project) = with(target) {
-        val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
-
-        pluginManager.withPlugin("org.jetbrains.kotlin.android") {
-            pluginManager.apply("com.google.devtools.ksp")
-        }
-        pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-            pluginManager.apply("com.google.devtools.ksp")
+        with(pluginManager) {
+            apply("com.google.dagger.hilt.android")
+            apply("com.google.devtools.ksp")
         }
 
-        pluginManager.withPlugin("com.android.base") {
-            pluginManager.apply("com.google.dagger.hilt.android")
-
-            dependencies {
-                add("implementation", libs.findLibrary("hilt-android").get())
-                add("ksp", libs.findLibrary("hilt-android-compiler").get())
-            }
+        dependencies {
+            add("implementation", libs.findLibrary("hilt-android").get())
+            add("ksp", libs.findLibrary("hilt-android-compiler").get())
         }
     }
-
 }
+

--- a/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -4,7 +4,7 @@ import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 
-class HiltConventionPlugin : Plugin<Project> {
+class AndroidHiltConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 

--- a/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -1,3 +1,5 @@
+import com.depromeet.team5.implementation
+import com.depromeet.team5.ksp
 import com.depromeet.team5.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -12,8 +14,8 @@ class AndroidHiltConventionPlugin : Plugin<Project> {
         }
 
         dependencies {
-            add("implementation", libs.findLibrary("hilt-android").get())
-            add("ksp", libs.findLibrary("hilt-android-compiler").get())
+            implementation(libs.findLibrary("hilt-android"))
+            ksp(libs.findLibrary("hilt-android-compiler").get())
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
@@ -1,0 +1,28 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class HiltConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+        pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+            pluginManager.apply("com.google.devtools.ksp")
+        }
+        pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+            pluginManager.apply("com.google.devtools.ksp")
+        }
+
+        pluginManager.withPlugin("com.android.base") {
+            pluginManager.apply("com.google.dagger.hilt.android")
+
+            dependencies {
+                add("implementation", libs.findLibrary("hilt-android").get())
+                add("ksp", libs.findLibrary("hilt-android-compiler").get())
+            }
+        }
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 #hilt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 
 #test
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -85,3 +86,4 @@ depromeet-team5-application = { id = "com.depromeet.team5.application", version 
 depromeet-team5-application-compose = { id = "com.depromeet.team5.application.compose", version = "unspecified" }
 depromeet-team5-library = { id = "com.depromeet.team5.library", version = "unspecified" }
 depromeet-team5-library-compose = { id = "com.depromeet.team5.library.compose", version = "unspecified" }
+depromeet-team5-hilt = { id = "com.depromeet.team5.hilt", version = "unspecified" }


### PR DESCRIPTION
### 변경사항 요약
- HiltConventionPlugin 생성
- 앱 묘듈에 개별 선언되어있던 hilt, ksp를 제거하고 팀 플러그인 한 줄로 전환

### 변경사항 설명
버전 모두 libs.versions.toml 카탈로그 사용했고, 추가 의존성 도입없이 Now In Android + 기존 코드 참고해서 구현해봤습니다!