### PR TITLE
[Feature] NM5-11 디자인 시스템 컴포넌트 (version1 마무리)

### DIFF
--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeButton.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeButton.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.depromeet.team5.core.designsystem.component.HedgeButton.Cta.Background
+import com.depromeet.team5.core.designsystem.component.HedgeButton.CallToAction.Background
 import com.depromeet.team5.core.designsystem.foundation.HedgeColor
 import com.depromeet.team5.core.designsystem.foundation.HedgeIcon
 import com.depromeet.team5.core.designsystem.foundation.HedgeTypography
@@ -236,7 +236,7 @@ object HedgeButton {
         }
     }
 
-    object Cta {
+    object CallToAction {
 
         sealed class Background {
             data object Transparent : Background()
@@ -559,24 +559,24 @@ fun CtaButtonPreview() {
             .background(HedgeColor.GREY_300),
         verticalArrangement = Arrangement.Bottom,
     ) {
-        HedgeButton.Cta.Single(
+        HedgeButton.CallToAction.Single(
             text = "버튼명",
             onClick = {},
         )
-        HedgeButton.Cta.Double(
+        HedgeButton.CallToAction.Double(
             text1 = "버튼1",
             text2 = "버튼2",
             onClickButton1 = {},
             onClickButton2 = {},
         )
-        HedgeButton.Cta.SingleWithSecondary(
+        HedgeButton.CallToAction.SingleWithSecondary(
             text = "버튼명",
             secondaryText = "Text",
             background = Background.Gradient(HedgeColor.Neutral.BackgroundDefault),
             onClickButton = {},
             onClickSecondaryButton = {},
         )
-        HedgeButton.Cta.DoubleWithSecondary(
+        HedgeButton.CallToAction.DoubleWithSecondary(
             text1 = "버튼1",
             text2 = "버튼2",
             secondaryText = "Text",

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeButton.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeButton.kt
@@ -228,7 +228,7 @@ object HedgeButton {
                     modifier = Modifier.size(
                         width = size.iconWidth, height = size.iconHeight
                     ),
-                    imageVector = imageVector,
+                    imageVector = it,
                     contentDescription = null,
                     tint = if (enabled) color.active else color.disabled,
                 )

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeButton.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeButton.kt
@@ -239,7 +239,7 @@ object HedgeButton {
     object CallToAction {
 
         sealed class Background {
-            data object Transparent : Background()
+            object Transparent : Background()
             data class Gradient(val color: Color) : Background()
         }
 

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeButton.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeButton.kt
@@ -1,0 +1,589 @@
+package com.depromeet.team5.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonColors
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.ripple
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.depromeet.team5.core.designsystem.component.HedgeButton.Cta.Background
+import com.depromeet.team5.core.designsystem.foundation.HedgeColor
+import com.depromeet.team5.core.designsystem.foundation.HedgeIcon
+import com.depromeet.team5.core.designsystem.foundation.HedgeTypography
+
+object HedgeButton {
+    object Action {
+        object Color {
+            object Filled {
+                val Primary: ButtonColors
+                    @Composable get() = ButtonDefaults.buttonColors(
+                        backgroundColor = HedgeColor.Brand.Primary,
+                        contentColor = HedgeColor.Text.White,
+                        disabledBackgroundColor = HedgeColor.Brand.Disabled,
+                        disabledContentColor = HedgeColor.Text.White,
+                    )
+
+                val Secondary: ButtonColors
+                    @Composable get() = ButtonDefaults.buttonColors(
+                        backgroundColor = HedgeColor.Brand.Secondary,
+                        contentColor = HedgeColor.Text.Title,
+                        disabledBackgroundColor = HedgeColor.Brand.Secondary,
+                        disabledContentColor = HedgeColor.Brand.Disabled,
+                    )
+            }
+        }
+
+        sealed class Size(
+            val contentPadding: PaddingValues,
+            val minWidth: Dp,
+            val minHeight: Dp,
+            val shape: Shape,
+            val textStyle: TextStyle,
+        ) {
+
+            data object Large : Size(
+                contentPadding = PaddingValues(horizontal = 32.dp, vertical = 16.dp),
+                minWidth = 96.dp,
+                minHeight = 56.dp,
+                shape = RoundedCornerShape(18.dp),
+                textStyle = HedgeTypography.Body1.SemiBold,
+            )
+
+            data object Medium : Size(
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 12.dp),
+                minWidth = 78.dp,
+                minHeight = 48.dp,
+                shape = RoundedCornerShape(14.dp),
+                textStyle = HedgeTypography.Body1.Medium,
+            )
+
+            data object Small : Size(
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp),
+                minWidth = 70.dp,
+                minHeight = 42.dp,
+                shape = RoundedCornerShape(12.dp),
+                textStyle = HedgeTypography.Body3.SemiBold,
+            )
+
+            data object Tiny : Size(
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                minWidth = 50.dp,
+                minHeight = 32.dp,
+                shape = RoundedCornerShape(8.dp),
+                textStyle = HedgeTypography.Label2.SemiBold,
+            )
+        }
+
+        @Composable
+        fun Filled(
+            text: CharSequence,
+            onClick: () -> Unit,
+            modifier: Modifier = Modifier,
+            buttonColors: ButtonColors = Color.Filled.Primary,
+            size: Size = Size.Large,
+            enabled: Boolean = true,
+            interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+        ) {
+            Button(
+                onClick = onClick,
+                modifier = modifier
+                    .widthIn(min = size.minWidth)
+                    .heightIn(min = size.minHeight),
+                colors = buttonColors,
+                enabled = enabled,
+                interactionSource = interactionSource,
+                elevation = null,
+                shape = size.shape,
+                contentPadding = size.contentPadding,
+            ) {
+                if (text is AnnotatedString) {
+                    Text(
+                        text = text,
+                        style = size.textStyle
+                    )
+                } else {
+                    Text(
+                        text = text.toString(),
+                        style = size.textStyle,
+                    )
+                }
+            }
+        }
+    }
+
+    object Text {
+        sealed class Color {
+
+            @get:Composable
+            abstract val active: androidx.compose.ui.graphics.Color
+
+            @get:Composable
+            abstract val disabled: androidx.compose.ui.graphics.Color
+
+            data object Primary : Color() {
+                override val active: androidx.compose.ui.graphics.Color
+                    @Composable get() = HedgeColor.Text.Title
+
+                override val disabled: androidx.compose.ui.graphics.Color
+                    @Composable get() = HedgeColor.Text.Disabled
+            }
+        }
+
+        sealed class Size(
+            val shape: RoundedCornerShape,
+            val textStyle: TextStyle,
+            val iconWidth: Dp,
+            val iconHeight: Dp,
+        ) {
+            data object Large : Size(
+                shape = RoundedCornerShape(8.dp),
+                textStyle = HedgeTypography.Body1.SemiBold,
+                iconWidth = 24.dp,
+                iconHeight = 24.dp,
+            )
+
+            data object Medium : Size(
+                shape = RoundedCornerShape(6.dp),
+                textStyle = HedgeTypography.Body3.SemiBold,
+                iconWidth = 20.dp,
+                iconHeight = 20.dp,
+            )
+
+            data object Small : Size(
+                shape = RoundedCornerShape(6.dp),
+                textStyle = HedgeTypography.Label2.SemiBold,
+                iconWidth = 16.dp,
+                iconHeight = 16.dp,
+            )
+        }
+    }
+
+    @Composable
+    fun Text(
+        text: CharSequence,
+        imageVector: ImageVector? = HedgeIcon.ArrowRightThin,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        size: Text.Size = Text.Size.Large,
+        color: Text.Color = Text.Color.Primary,
+        enabled: Boolean = true,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    ) {
+        Row(
+            modifier = modifier
+                .clip(size.shape)
+                .clickable(
+                    enabled = enabled,
+                    interactionSource = interactionSource,
+                    indication = ripple(),
+                    onClick = onClick
+                )
+                .padding(horizontal = 6.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            if (text is AnnotatedString) {
+                Text(
+                    text = text,
+                    style = size.textStyle,
+                    color = if (enabled) color.active else color.disabled
+                )
+            } else {
+                Text(
+                    text = text.toString(),
+                    style = size.textStyle,
+                    color = if (enabled) color.active else color.disabled
+                )
+            }
+            imageVector?.let {
+                Icon(
+                    modifier = Modifier.size(
+                        width = size.iconWidth, height = size.iconHeight
+                    ),
+                    imageVector = imageVector,
+                    contentDescription = null,
+                    tint = if (enabled) color.active else color.disabled,
+                )
+            }
+        }
+    }
+
+    object Cta {
+
+        sealed class Background {
+            data object Transparent : Background()
+            data class Gradient(val color: Color) : Background()
+        }
+
+        @Composable
+        fun Single(
+            text: CharSequence,
+            onClick: () -> Unit,
+            modifier: Modifier = Modifier,
+            background: Background = Background.Transparent,
+        ) {
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .ctaBackground(background)
+                    .padding(top = 24.dp, bottom = 20.dp, start = 20.dp, end = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Action.Filled(
+                    text = text,
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = onClick
+                )
+            }
+        }
+
+        @Composable
+        fun Double(
+            text1: CharSequence,
+            text2: CharSequence,
+            onClickButton1: () -> Unit,
+            onClickButton2: () -> Unit,
+            modifier: Modifier = Modifier,
+            background: Background = Background.Transparent,
+        ) {
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .ctaBackground(background)
+                    .padding(top = 24.dp, bottom = 20.dp, start = 20.dp, end = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Action.Filled(
+                        text = text2,
+                        buttonColors = Action.Color.Filled.Secondary,
+                        modifier = Modifier.weight(1f),
+                        onClick = onClickButton2
+                    )
+                    Action.Filled(
+                        text = text1,
+                        modifier = Modifier.weight(1f),
+                        onClick = onClickButton1
+                    )
+                }
+            }
+        }
+
+        @Composable
+        fun SingleWithSecondary(
+            text: CharSequence,
+            secondaryText: CharSequence,
+            onClickButton: () -> Unit,
+            onClickSecondaryButton: () -> Unit,
+            modifier: Modifier = Modifier,
+            background: Background = Background.Transparent,
+            secondaryImageVector: ImageVector? = null,
+        ) {
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .ctaBackground(background)
+                    .padding(top = 24.dp, bottom = 20.dp, start = 20.dp, end = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Action.Filled(
+                    text = text,
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = onClickButton
+                )
+                Text(
+                    text = secondaryText,
+                    size = Text.Size.Large,
+                    imageVector = secondaryImageVector,
+                    onClick = onClickSecondaryButton
+                )
+            }
+        }
+
+        @Composable
+        fun DoubleWithSecondary(
+            text1: CharSequence,
+            text2: CharSequence,
+            secondaryText: CharSequence,
+            onClickButton1: () -> Unit,
+            onClickButton2: () -> Unit,
+            onClickSecondaryButton: () -> Unit,
+            modifier: Modifier = Modifier,
+            background: Background = Background.Transparent,
+            secondaryImageVector: ImageVector? = null,
+        ) {
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .ctaBackground(background)
+                    .padding(top = 24.dp, bottom = 20.dp, start = 20.dp, end = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Action.Filled(
+                        text = text2,
+                        buttonColors = Action.Color.Filled.Secondary,
+                        modifier = Modifier.weight(1f),
+                        onClick = onClickButton2
+                    )
+                    Action.Filled(
+                        text = text1,
+                        modifier = Modifier.weight(1f),
+                        onClick = onClickButton1
+                    )
+                }
+                Text(
+                    text = secondaryText,
+                    size = Text.Size.Large,
+                    imageVector = secondaryImageVector,
+                    onClick = onClickSecondaryButton
+                )
+            }
+        }
+    }
+
+    private fun Modifier.ctaBackground(background: Background): Modifier = when (background) {
+        Background.Transparent -> this
+        is Background.Gradient -> this.then(
+            Modifier.composed {
+                val brush = remember(background.color) {
+                    Brush.verticalGradient(
+                        0f to Color.Transparent,
+                        0.21f to background.color
+                    )
+                }
+                Modifier.background(brush)
+            }
+        )
+    }
+}
+
+
+@Composable
+@Preview
+fun FilledButtonPreview() {
+    Column(
+        modifier = Modifier
+            .background(HedgeColor.Neutral.BackgroundDefault)
+            .padding(vertical = 48.dp, horizontal = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            listOf(true, false).forEach { enabled ->
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    HedgeButton.Action.Filled(
+                        text = "Primary",
+                        enabled = enabled,
+                        onClick = {}
+                    )
+                    HedgeButton.Action.Filled(
+                        text = "Primary",
+                        size = HedgeButton.Action.Size.Medium,
+                        enabled = enabled,
+                        onClick = {}
+                    )
+                    HedgeButton.Action.Filled(
+                        text = "Primary",
+                        size = HedgeButton.Action.Size.Small,
+                        enabled = enabled,
+                        onClick = {}
+                    )
+                    HedgeButton.Action.Filled(
+                        text = "Primary",
+                        size = HedgeButton.Action.Size.Tiny,
+                        enabled = enabled,
+                        onClick = {}
+                    )
+                }
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            listOf(true, false).forEach { enabled ->
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    HedgeButton.Action.Filled(
+                        text = "Secondary",
+                        buttonColors = HedgeButton.Action.Color.Filled.Secondary,
+                        enabled = enabled,
+                        onClick = {}
+                    )
+                    HedgeButton.Action.Filled(
+                        text = "Secondary",
+                        buttonColors = HedgeButton.Action.Color.Filled.Secondary,
+                        size = HedgeButton.Action.Size.Medium,
+                        enabled = enabled,
+                        onClick = {}
+                    )
+                    HedgeButton.Action.Filled(
+                        text = "Secondary",
+                        buttonColors = HedgeButton.Action.Color.Filled.Secondary,
+                        size = HedgeButton.Action.Size.Small,
+                        enabled = enabled,
+                        onClick = {}
+                    )
+                    HedgeButton.Action.Filled(
+                        text = "Secondary",
+                        buttonColors = HedgeButton.Action.Color.Filled.Secondary,
+                        size = HedgeButton.Action.Size.Tiny,
+                        enabled = enabled,
+                        onClick = {}
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+fun TextButtonPreview() {
+    Column(
+        modifier = Modifier
+            .background(HedgeColor.Neutral.BackgroundDefault)
+            .padding(vertical = 48.dp, horizontal = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            listOf(true, false).forEach { enabled ->
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    HedgeButton.Text(
+                        text = "Primary",
+                        enabled = enabled,
+                        onClick = {},
+                    )
+                    HedgeButton.Text(
+                        text = "Primary",
+                        enabled = enabled,
+                        size = HedgeButton.Text.Size.Medium,
+                        onClick = {},
+                    )
+                    HedgeButton.Text(
+                        text = "Primary",
+                        enabled = enabled,
+                        size = HedgeButton.Text.Size.Small,
+                        onClick = {},
+                    )
+                }
+            }
+
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            listOf(true, false).forEach { enabled ->
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    HedgeButton.Text(
+                        text = "Primary",
+                        imageVector = null,
+                        enabled = enabled,
+                        onClick = {},
+                    )
+                    HedgeButton.Text(
+                        text = "Primary",
+                        imageVector = null,
+                        enabled = enabled,
+                        size = HedgeButton.Text.Size.Medium,
+                        onClick = {},
+                    )
+                    HedgeButton.Text(
+                        text = "Primary",
+                        imageVector = null,
+                        enabled = enabled,
+                        size = HedgeButton.Text.Size.Small,
+                        onClick = {},
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+fun CtaButtonPreview() {
+    Column(
+        modifier = Modifier
+            .background(HedgeColor.GREY_300),
+        verticalArrangement = Arrangement.Bottom,
+    ) {
+        HedgeButton.Cta.Single(
+            text = "버튼명",
+            onClick = {},
+        )
+        HedgeButton.Cta.Double(
+            text1 = "버튼1",
+            text2 = "버튼2",
+            onClickButton1 = {},
+            onClickButton2 = {},
+        )
+        HedgeButton.Cta.SingleWithSecondary(
+            text = "버튼명",
+            secondaryText = "Text",
+            background = Background.Gradient(HedgeColor.Neutral.BackgroundDefault),
+            onClickButton = {},
+            onClickSecondaryButton = {},
+        )
+        HedgeButton.Cta.DoubleWithSecondary(
+            text1 = "버튼1",
+            text2 = "버튼2",
+            secondaryText = "Text",
+            background = Background.Gradient(HedgeColor.Neutral.BackgroundDefault),
+            onClickButton1 = {},
+            onClickButton2 = {},
+            onClickSecondaryButton = {},
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeSegment.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeSegment.kt
@@ -1,0 +1,216 @@
+package com.depromeet.team5.core.designsystem.component
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.depromeet.team5.core.designsystem.foundation.HedgeColor
+import com.depromeet.team5.core.designsystem.foundation.HedgeTypography
+
+@Stable
+interface HedgeSegmentColor {
+
+    val track: Color
+        @Composable get
+
+    @Composable
+    fun thumb(selected: Boolean): Color
+
+    @Composable
+    fun text(selected: Boolean): Color
+}
+
+@Stable
+interface HedgeSegmentStyle {
+    val trackShape: Shape
+    val thumbShape: Shape
+    val thumbPadding: PaddingValues
+    val trackPadding: PaddingValues
+    val thumbElevation: Dp
+    val textStyle: TextStyle
+}
+
+object HedgeSegmentDefaults {
+    @Composable
+    fun color(
+        track: Color = HedgeColor.GREY_OPACITY_200,
+        thumbSelected: Color = HedgeColor.Neutral.BackgroundDefault,
+        thumbUnselected: Color = Color.Transparent,
+        selectedText: Color = HedgeColor.Text.Title,
+        unselectedText: Color = HedgeColor.Text.Alternative,
+    ) = object : HedgeSegmentColor {
+
+        override val track: Color
+            @Composable get() = track
+
+        @Composable
+        override fun thumb(selected: Boolean) =
+            if (selected) thumbSelected else thumbUnselected
+
+        @Composable
+        override fun text(selected: Boolean) =
+            if (selected) selectedText else unselectedText
+    }
+
+    @Composable
+    fun style(
+        trackShape: Shape = RoundedCornerShape(8.dp),
+        thumbShape: Shape = RoundedCornerShape(6.dp),
+        trackPadding: PaddingValues = PaddingValues(all = 3.dp),
+        thumbPadding: PaddingValues = PaddingValues(horizontal = 7.dp, vertical = 6.dp),
+        thumbElevation: Dp = 4.5.dp,
+        textStyle: TextStyle = HedgeTypography.Caption1.Semibold,
+    ) = object : HedgeSegmentStyle {
+        override val trackShape = trackShape
+        override val thumbShape = thumbShape
+        override val trackPadding = trackPadding
+        override val thumbPadding = thumbPadding
+        override val thumbElevation = thumbElevation
+        override val textStyle = textStyle
+    }
+}
+
+@Composable
+fun HedgeSegment(
+    options: List<CharSequence>,
+    selectedIndex: Int,
+    onSelectedIndexChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    color: HedgeSegmentColor = HedgeSegmentDefaults.color(),
+    style: HedgeSegmentStyle = HedgeSegmentDefaults.style(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    require(options.size >= 2)
+    require(selectedIndex in options.indices)
+
+    val density = LocalDensity.current
+    var trackWidthPx by remember { mutableIntStateOf(0) }
+    var trackHeightPx by remember { mutableIntStateOf(0) }
+
+    Box(
+        modifier = modifier
+            .background(color.track, style.trackShape)
+            .padding(style.trackPadding)
+            .onSizeChanged {
+                trackWidthPx = it.width
+                trackHeightPx = it.height
+            },
+        contentAlignment = Alignment.CenterStart
+    ) {
+
+        val segmentWidthPx = trackWidthPx / options.size.toFloat()
+        val targetX = selectedIndex * segmentWidthPx
+        val x by animateFloatAsState(targetValue = targetX, label = "thumbX")
+
+        Box(
+            modifier = Modifier
+                .height(with(density) { trackHeightPx.toDp() })
+                .width(with(density) { segmentWidthPx.toDp() })
+                .graphicsLayer {
+                    shape = style.thumbShape
+                    clip = true
+                    shadowElevation = style.thumbElevation.toPx()
+                    ambientShadowColor = Color.Black.copy(alpha = 0.8f)
+                    spotShadowColor = Color.Black.copy(alpha = 0.8f)
+                    translationX = x
+                }
+                .background(color.thumb(true), style.thumbShape)
+        )
+
+        Row(
+            modifier = Modifier.width(IntrinsicSize.Max),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            options.forEachIndexed { index, text ->
+                Box(
+                    modifier = Modifier
+                        .clickable(
+                            enabled = enabled,
+                            interactionSource = interactionSource,
+                            indication = null
+                        ) { if (index != selectedIndex) onSelectedIndexChange(index) }
+                        .weight(1f)
+                        .padding(style.thumbPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (text is AnnotatedString) {
+                        Text(
+                            text = text,
+                            style = style.textStyle,
+                            color = color.text(index == selectedIndex),
+                            maxLines = 1,
+                            textAlign = TextAlign.Center
+                        )
+                    } else {
+                        Text(
+                            text = text.toString(),
+                            style = style.textStyle,
+                            color = color.text(index == selectedIndex),
+                            maxLines = 1,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+fun HedgeSegmentPreview() {
+    var idx by remember { mutableIntStateOf(0) }
+    Column(
+        modifier = Modifier
+            .background(color = HedgeColor.Neutral.BackgroundDefault)
+            .padding(horizontal = 20.dp, vertical = 120.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        HedgeSegment(
+            options = listOf("Label", "Label"),
+            selectedIndex = idx,
+            onSelectedIndexChange = { idx = it }
+        )
+        HedgeSegment(
+            options = listOf("원", "$"),
+            selectedIndex = idx,
+            onSelectedIndexChange = { idx = it },
+        )
+        HedgeSegment(
+            options = listOf("Longgggggggggg", "Short"),
+            selectedIndex = idx,
+            onSelectedIndexChange = { idx = it },
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeSwitch.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeSwitch.kt
@@ -1,0 +1,174 @@
+package com.depromeet.team5.core.designsystem.component
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.depromeet.team5.core.designsystem.foundation.HedgeColor
+
+@Stable
+interface HedgeSwitchColor {
+    @Composable
+    fun trackColor(checked: Boolean): Color
+
+    @Composable
+    fun thumbColor(checked: Boolean): Color
+}
+
+@Stable
+interface HedgeSwitchStyle {
+    val trackWidth: Dp
+    val trackHeight: Dp
+    val trackPadding: Dp
+    val thumbSize: Dp
+    val trackShape: Shape
+    val thumbShape: Shape
+}
+
+@Stable
+private class DefaultHedgeSwitchColor(
+    private val checkedTrack: Color,
+    private val uncheckedTrack: Color,
+    private val checkedThumb: Color,
+    private val uncheckedThumb: Color,
+) : HedgeSwitchColor {
+    @Composable
+    override fun trackColor(checked: Boolean) =
+        if (checked) checkedTrack else uncheckedTrack
+
+    @Composable
+    override fun thumbColor(checked: Boolean) =
+        if (checked) checkedThumb else uncheckedThumb
+}
+
+object HedgeSwitchDefaults {
+
+    @Composable
+    fun style(
+        trackWidth: Dp = 45.dp,
+        trackHeight: Dp = 28.dp,
+        trackPadding: Dp = 3.dp,
+        thumbSize: Dp = 22.dp,
+        trackShape: Shape = CircleShape,
+        thumbShape: Shape = CircleShape,
+    ) = object : HedgeSwitchStyle {
+        override val trackWidth = trackWidth
+        override val trackHeight = trackHeight
+        override val trackPadding = trackPadding
+        override val thumbSize = thumbSize
+        override val trackShape = trackShape
+        override val thumbShape = thumbShape
+    }
+
+    @Composable
+    fun color(
+        checkedTrack: Color = HedgeColor.Brand.Primary,
+        uncheckedTrack: Color = HedgeColor.GREY_OPACITY_300,
+        checkedThumb: Color = HedgeColor.Neutral.BackgroundDefault,
+        uncheckedThumb: Color = HedgeColor.Neutral.BackgroundDefault,
+    ) = object : HedgeSwitchColor {
+
+        @Composable
+        override fun trackColor(checked: Boolean) =
+            if (checked) checkedTrack else uncheckedTrack
+
+        @Composable
+        override fun thumbColor(checked: Boolean) =
+            if (checked) checkedThumb else uncheckedThumb
+    }
+}
+
+@Composable
+fun HedgeSwitch(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    color: HedgeSwitchColor = HedgeSwitchDefaults.color(),
+    style: HedgeSwitchStyle = HedgeSwitchDefaults.style(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    val density = LocalDensity.current
+
+
+    val trackColor by animateColorAsState(
+        color.trackColor(checked),
+        label = "trackColor"
+    )
+
+    val thumbOffset by animateDpAsState(
+        if (checked) style.trackWidth - style.thumbSize - style.trackPadding else style.trackPadding,
+        label = "thumbOffset"
+    )
+    val thumbOffsetPx = with(density) { thumbOffset.toPx() }
+
+
+    Box(
+        modifier = modifier
+            .width(style.trackWidth)
+            .height(style.trackHeight)
+            .background(
+                color = trackColor,
+                shape = style.trackShape
+            )
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = { onCheckedChange(!checked) }
+            ),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Box(
+            modifier = Modifier
+                .offset { IntOffset(x = thumbOffsetPx.toInt(), y = 0) }
+                .size(style.thumbSize)
+                .background(
+                    color = color.thumbColor(checked),
+                    shape = style.thumbShape
+                )
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun SwitchPreview() {
+    Column(
+        modifier = Modifier.padding(100.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        var checked by remember { mutableStateOf(false) }
+        HedgeSwitch(
+            checked = checked,
+            onCheckedChange = { checked = it },
+        )
+        HedgeSwitch(
+            checked = checked.not(),
+            onCheckedChange = { checked = it },
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeSwitch.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeSwitch.kt
@@ -114,7 +114,6 @@ fun HedgeSwitch(
 ) {
     val density = LocalDensity.current
 
-
     val trackColor by animateColorAsState(
         color.trackColor(checked),
         label = "trackColor"
@@ -125,7 +124,6 @@ fun HedgeSwitch(
         label = "thumbOffset"
     )
     val thumbOffsetPx = with(density) { thumbOffset.toPx() }
-
 
     Box(
         modifier = modifier

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeTextField.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeTextField.kt
@@ -1,0 +1,291 @@
+package com.depromeet.team5.core.designsystem.component
+
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.depromeet.team5.core.designsystem.component.HedgeTextFieldDefaults.Search.searchColor
+import com.depromeet.team5.core.designsystem.component.HedgeTextFieldDefaults.Search.searchIcon
+import com.depromeet.team5.core.designsystem.component.HedgeTextFieldDefaults.Search.searchStyle
+import com.depromeet.team5.core.designsystem.foundation.HedgeColor
+import com.depromeet.team5.core.designsystem.foundation.HedgeIcon
+import com.depromeet.team5.core.designsystem.foundation.HedgeTypography
+
+@Stable
+interface HedgeSearchFieldColor {
+    val container: Color
+    val placeholder: Color
+    val text: Color
+    val border: Color
+}
+
+@Stable
+interface HedgeSearchFieldStyle {
+    val shape: Shape
+    val contentPadding: PaddingValues
+    val textStyle: TextStyle
+    val placeholderStyle: TextStyle
+    val borderWidth: Dp
+}
+
+@Stable
+interface HedgeSearchFieldIcon {
+    val icon: ImageVector
+    val tint: Color
+    val enabled: Boolean
+    val indication: Indication?
+    val contentDescription: String?
+    val interactionSource: MutableInteractionSource
+    val onClick: (() -> Unit)?
+}
+
+object HedgeTextFieldDefaults {
+
+    object Search {
+        @Composable
+        fun searchColor(
+            container: Color = HedgeColor.Brand.Secondary,
+            placeholder: Color = HedgeColor.Text.Assistive,
+            text: Color = HedgeColor.Text.Title,
+            border: Color = HedgeColor.Transparent,
+        ): HedgeSearchFieldColor = object : HedgeSearchFieldColor {
+            override val container = container
+            override val placeholder = placeholder
+            override val text = text
+            override val border = border
+        }
+
+        @Composable
+        fun searchStyle(
+            shape: Shape = RoundedCornerShape(14.dp),
+            contentPadding: PaddingValues = PaddingValues(start = 2.dp, end = 10.dp, top = 2.dp, bottom = 2.dp),
+            textStyle: TextStyle = HedgeTypography.Body1.Medium,
+            placeholderStyle: TextStyle = HedgeTypography.Body1.Medium,
+            borderWidth: Dp = 0.dp,
+        ): HedgeSearchFieldStyle = object : HedgeSearchFieldStyle {
+            override val shape = shape
+            override val contentPadding = contentPadding
+            override val textStyle = textStyle
+            override val placeholderStyle = placeholderStyle
+            override val borderWidth = borderWidth
+        }
+
+        @Composable
+        fun searchIcon(
+            icon: ImageVector,
+            tint: Color = HedgeColor.Text.Alternative,
+            enabled: Boolean = true,
+            indication: Indication? = null,
+            contentDescription: String? = null,
+            interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+            onClick: (() -> Unit)? = null,
+        ): HedgeSearchFieldIcon = object : HedgeSearchFieldIcon {
+            override val icon = icon
+            override val tint = tint
+            override val enabled = enabled
+            override val indication = indication
+            override val contentDescription = contentDescription
+            override val interactionSource = interactionSource
+            override val onClick = onClick
+        }
+    }
+}
+
+object HedgeTextField {
+
+    @Composable
+    fun Search(
+        value: String,
+        onValueChange: (String) -> Unit,
+        modifier: Modifier = Modifier,
+        placeholder: String? = null,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+        colors: HedgeSearchFieldColor = searchColor(),
+        style: HedgeSearchFieldStyle = searchStyle(),
+        leadingIcon: HedgeSearchFieldIcon? = searchIcon(
+            icon = HedgeIcon.Search,
+            enabled = false,
+            contentDescription = "search",
+        ),
+        trailingIcon: HedgeSearchFieldIcon? = searchIcon(
+            icon = HedgeIcon.CloseFill,
+            enabled = true,
+            contentDescription = "clear",
+            onClick = { onValueChange("") }
+        ),
+        visualTransformation: VisualTransformation = VisualTransformation.None,
+        keyboardController: SoftwareKeyboardController? = LocalSoftwareKeyboardController.current,
+        keyboardOptions: KeyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+        keyboardActions: KeyboardActions = KeyboardActions(
+            onSearch = {
+                leadingIcon?.onClick?.invoke()
+                keyboardController?.hide()
+            },
+            onDone = {
+                leadingIcon?.onClick?.invoke()
+                keyboardController?.hide()
+            }
+        ),
+    ) {
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier
+                .border(style.borderWidth, colors.border, style.shape)
+                .background(
+                    color = colors.container,
+                    shape = style.shape,
+                )
+                .padding(style.contentPadding),
+            singleLine = true,
+            textStyle = style.textStyle.copy(color = colors.text),
+            cursorBrush = SolidColor(HedgeColor.Text.Title),
+            interactionSource = interactionSource,
+            visualTransformation = visualTransformation,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            decorationBox = { inner ->
+                Row(
+                    modifier = Modifier,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    leadingIcon?.let {
+                        Icon(
+                            modifier = Modifier
+                                .then(
+                                    if (leadingIcon.enabled)
+                                        Modifier
+                                            .clip(CircleShape)
+                                            .clickable(
+                                                interactionSource = leadingIcon.interactionSource,
+                                                onClick = { leadingIcon.onClick?.invoke() }
+                                            )
+                                    else Modifier
+                                )
+                                .padding(8.dp),
+                            imageVector = it.icon,
+                            contentDescription = leadingIcon.contentDescription,
+                            tint = leadingIcon.tint,
+                        )
+                    } ?: Spacer(Modifier.size(40.dp))
+
+                    Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
+                        inner()
+                        if (value.isEmpty() && !placeholder.isNullOrEmpty()) {
+                            Text(
+                                text = placeholder,
+                                style = style.placeholderStyle,
+                                color = colors.placeholder
+                            )
+                        }
+                    }
+
+                    if (trailingIcon != null && trailingIcon.enabled && value.isNotEmpty()) {
+                        Icon(
+                            imageVector = trailingIcon.icon,
+                            contentDescription = "clear",
+                            tint = trailingIcon.tint,
+                            modifier = Modifier
+                                .then(
+                                    if (trailingIcon.enabled)
+                                        Modifier
+                                            .clip(CircleShape)
+                                            .clickable(
+                                                indication = trailingIcon.indication,
+                                                interactionSource = trailingIcon.interactionSource,
+                                                onClick = { trailingIcon.onClick?.invoke() }
+                                            )
+                                    else
+                                        Modifier
+                                )
+                                .padding(8.dp)
+                        )
+                    } else {
+                        Spacer(Modifier.size(40.dp))
+                    }
+                }
+            }
+        )
+    }
+}
+
+@Composable
+@Preview
+fun SearchPreview() {
+    var text1 by remember { mutableStateOf("") }
+    var text2 by remember { mutableStateOf("trailing icon null") }
+    var text3 by remember { mutableStateOf("leading icon disabled, trailing icon enabled") }
+    var text4 by remember { mutableStateOf("leading icon enabled") }
+
+    Column(Modifier.padding(horizontal = 20.dp, vertical = 100.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        HedgeTextField.Search(
+            value = text1,
+            onValueChange = { text1 = it },
+            placeholder = "종목 검색",
+        )
+        HedgeTextField.Search(
+            value = text2,
+            onValueChange = { text2 = it },
+            trailingIcon = null,
+            placeholder = "종목 검색",
+        )
+        HedgeTextField.Search(
+            value = text3,
+            onValueChange = { text3 = it },
+            placeholder = "종목 검색",
+        )
+
+        val keyboardController = LocalSoftwareKeyboardController.current
+        HedgeTextField.Search(
+            value = text4,
+            onValueChange = { text4 = it },
+            leadingIcon = searchIcon(
+                icon = HedgeIcon.Search,
+                enabled = true,
+                onClick = {
+                    keyboardController?.hide()
+                    // do something
+                }
+            ),
+            trailingIcon = null,
+            placeholder = "종목 검색",
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeToast.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeToast.kt
@@ -1,0 +1,133 @@
+package com.depromeet.team5.core.designsystem.component
+
+import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.depromeet.team5.core.designsystem.R
+import com.depromeet.team5.core.designsystem.foundation.HedgeColor
+import com.depromeet.team5.core.designsystem.foundation.HedgeTypography
+import kotlinx.coroutines.delay
+
+@Composable
+fun HedgeToast(
+    text: CharSequence,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = HedgeColor.Text.Secondary,
+    textColor: Color = HedgeColor.Brand.Secondary,
+    textStyle: TextStyle = HedgeTypography.Body3.Medium,
+    icon: ImageVector? = null,
+    iconTint: Color = Color.Unspecified,
+    duration: Int = Toast.LENGTH_SHORT,
+    topOffset: Dp = 52.dp,
+    fadeInMs: Int = 800,
+    fadeOutMs: Int = 800,
+    onDismiss: (() -> Unit)? = null,
+) {
+    val visibleState = remember { MutableTransitionState(false) }
+    val durationMillis = if (duration == Toast.LENGTH_SHORT) 2000L else 3500L
+
+    LaunchedEffect(Unit) {
+        visibleState.targetState = true
+        delay(durationMillis)
+        visibleState.targetState = false
+        onDismiss?.invoke()
+    }
+
+    AnimatedVisibility(
+        visibleState = visibleState,
+        enter = fadeIn(animationSpec = tween(fadeInMs)),
+        exit = fadeOut(animationSpec = tween(fadeOutMs))
+    ) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(top = topOffset),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Row(
+                modifier = Modifier
+                    .heightIn(52.dp)
+                    .background(
+                        color = backgroundColor,
+                        shape = RoundedCornerShape(100)
+                    )
+                    .padding(start = 10.dp, end = 20.dp, top = 10.dp, bottom = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                icon?.let {
+                    Icon(
+                        imageVector = it,
+                        contentDescription = it.name,
+                        tint = iconTint,
+                    )
+                }
+                Spacer(
+                    Modifier.then(
+                        if (icon != null) Modifier.size(8.dp) else Modifier.size(10.dp)
+                    )
+                )
+                if (text is AnnotatedString) {
+                    Text(
+                        text = text,
+                        color = textColor,
+                        style = textStyle,
+                    )
+                } else {
+                    Text(
+                        text = text.toString(),
+                        color = textColor,
+                        style = textStyle,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun HedgeToastPreview() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.statusBars)
+    ) {
+        HedgeToast(
+            text = "매도 기록을 모두 입력해 주세요",
+            icon = ImageVector.vectorResource(R.drawable.ic_toast_error),
+            duration = Toast.LENGTH_SHORT
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeTopBar.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/component/HedgeTopBar.kt
@@ -1,0 +1,112 @@
+package com.depromeet.team5.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.depromeet.team5.core.designsystem.foundation.HedgeColor
+import com.depromeet.team5.core.designsystem.foundation.HedgeIcon
+import com.depromeet.team5.core.designsystem.foundation.HedgeTypography
+
+/*
+* todo migrate to ui module
+* */
+@Composable
+private fun HedgeTopBarBackDefault() {
+    Icon(
+        imageVector = HedgeIcon.ArrowLeftThick,
+        contentDescription = "back",
+    )
+}
+
+private fun Modifier.topBarBackground(color: Color?): Modifier =
+    if (color == null) this else this.then(Modifier.background(color))
+
+@Composable
+fun HedgeTopBar(
+    onClickBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color? = null,
+    back: @Composable () -> Unit = { HedgeTopBarBackDefault() },
+    title: (@Composable () -> Unit)? = null,
+    action: (@Composable () -> Unit)? = null,
+) {
+    val interaction = remember { MutableInteractionSource() }
+
+    Row(
+        modifier = modifier
+            .topBarBackground(backgroundColor)
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .fillMaxWidth()
+            .height(44.dp)
+            .padding(start = 4.dp, end = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .padding(vertical = 2.dp)
+                .clip(CircleShape)
+                .clickable(
+                    interactionSource = interaction,
+                    indication = ripple(),
+                    onClick = onClickBack
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            back()
+        }
+
+        Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+            title?.invoke()
+        }
+        action?.invoke()
+    }
+}
+
+@Composable
+@Preview
+private fun HedgeTopBarPreview() {
+    Column {
+        HedgeTopBar(
+            onClickBack = { },
+            backgroundColor = HedgeColor.Neutral.BackgroundDefault,
+            title = {
+                Text(
+                    text = "제목",
+                    style = HedgeTypography.Headline2.SemiBold,
+                )
+            },
+            action = {
+                HedgeButton.Text(
+                    text = "다음",
+                    imageVector = null,
+                    onClick = { },
+                    size = HedgeButton.Text.Size.Large,
+                    color = HedgeButton.Text.Color.Primary,
+                )
+            }
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/foundation/HedgeColor.kt
+++ b/core/designsystem/src/main/java/com/depromeet/team5/core/designsystem/foundation/HedgeColor.kt
@@ -104,6 +104,12 @@ object HedgeColor {
             )
     }
 
+    val Transparent: Color
+        @Composable get() = com.depromeet.team5.core.designsystem.util.Color(
+            lightMode = Color(0x00000000),
+            darkMode = Color(0x00000000)
+        )
+
     /*
     * palette
     * todo 추후 internal로 변경하고 semantic만 노출(아직 semantic 정의가 다 안 되었고, 피그마 화면에 연결도 안 되어있음)

--- a/core/designsystem/src/main/res/drawable/ic_toast_check.xml
+++ b/core/designsystem/src/main/res/drawable/ic_toast_check.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+    <path
+        android:pathData="M16,6L16,6A10,10 0,0 1,26 16L26,16A10,10 0,0 1,16 26L16,26A10,10 0,0 1,6 16L6,16A10,10 0,0 1,16 6z"
+        android:fillColor="#22D95F" />
+    <path
+        android:pathData="M16,3L16,3A13,13 0,0 1,29 16L29,16A13,13 0,0 1,16 29L16,29A13,13 0,0 1,3 16L3,16A13,13 0,0 1,16 3z"
+        android:strokeAlpha="0.1"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeColor="#191A20" />
+    <path
+        android:pathData="M19.6,13.3L14.231,18.7L12.4,16.859"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#4B5563"
+        android:strokeLineCap="round" />
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_toast_copy.xml
+++ b/core/designsystem/src/main/res/drawable/ic_toast_copy.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+    <path
+        android:pathData="M16,16m-15,0a15,15 0,1 1,30 0a15,15 0,1 1,-30 0"
+        android:fillColor="#191A20"
+        android:fillAlpha="0.1" />
+    <path
+        android:pathData="M21.333,16.75L21.333,12C21.333,10.895 20.438,10 19.333,10L14.583,10M17.333,22L12.833,22C12.005,22 11.333,21.328 11.333,20.5L11.333,14C11.333,13.172 12.005,12.5 12.833,12.5L17.333,12.5C18.161,12.5 18.833,13.172 18.833,14L18.833,20.5C18.833,21.328 18.161,22 17.333,22Z"
+        android:strokeWidth="1.33333"
+        android:fillColor="#00000000"
+        android:strokeColor="#F4F5F7"
+        android:strokeLineCap="round" />
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_toast_error.xml
+++ b/core/designsystem/src/main/res/drawable/ic_toast_error.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+    <path
+        android:pathData="M16,6L16,6A10,10 0,0 1,26 16L26,16A10,10 0,0 1,16 26L16,26A10,10 0,0 1,6 16L6,16A10,10 0,0 1,16 6z"
+        android:fillColor="#EDDC21" />
+    <path
+        android:pathData="M16,3L16,3A13,13 0,0 1,29 16L29,16A13,13 0,0 1,16 29L16,29A13,13 0,0 1,3 16L3,16A13,13 0,0 1,16 3z"
+        android:strokeAlpha="0.1"
+        android:strokeWidth="6"
+        android:fillColor="#00000000"
+        android:strokeColor="#191A20" />
+    <path
+        android:pathData="M16,11.4L16,11.4A1,1 0,0 1,17 12.4L17,15.6A1,1 0,0 1,16 16.6L16,16.6A1,1 0,0 1,15 15.6L15,12.4A1,1 0,0 1,16 11.4z"
+        android:fillColor="#4B5563" />
+    <path
+        android:pathData="M16,19.6m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0"
+        android:fillColor="#4B5563" />
+</vector>


### PR DESCRIPTION
[NM5-11](https://depromeet05.atlassian.net/jira/software/projects/NM5/boards/68?selectedIssue=NM5-11)
### 변경사항 설명
- done
  - design system : Button, Segment, Switch, Toast, TextField.Search, TopBar(UI모듈로 이동 예정)
- todo
  - Theme
    - as-is
      - design system 모듈에 semantic 컬러들을 feature에서 직접 접근 HedgeColor.Neutral.BackgroundDefault
    - to-be
      - design system 모듈에는 color scheme들만, ui 모듈에서 Materialtheme이 아닌 커스텀 Color Pallete로 HedgeTheme 구현하여 feature에선 ui 모듈의  HedgeTheme.Neutral.BackgroundDefault 로 접근
  - ui module
    - Compound TextField, List, TopBar, Top, Modal
    - 해당 컴포넌트 사용하는 화면 구현하는 사람이 구현 or 영진 구현

### 스크린샷 (선택사항)

 | Action.Filled | Text | CTA |
 | :-----: | :-----: | :-----: | 
 |  <img width="211" height="306" alt="image" src="https://github.com/user-attachments/assets/68d559b7-8782-429d-93fe-0f7ab21393cd" /> | <img width="204" height="166" alt="image" src="https://github.com/user-attachments/assets/e3197b7a-05be-4dab-9002-5d89cf776a30" /> | <img width="247" height="299" alt="image" src="https://github.com/user-attachments/assets/df3dd1e2-1852-49ab-af43-fd7e99590d87" /> |

 | HedgeSwitch |
 | :-----: | 
 | <img width="178" height="195" alt="image" src="https://github.com/user-attachments/assets/627a90b5-e41c-41e1-ab26-72ca09900f3e" /> |  
 
 | HedgeSegment |
 | :-----: | 
 | <img width="218" height="279" alt="image" src="https://github.com/user-attachments/assets/698c9a16-eb29-4943-9752-387a4712ef8a" /> |  

 | HedgeSegment |
 | :-----: | 
 | <img width="631" height="149" alt="image" src="https://github.com/user-attachments/assets/1f888539-c27e-4ec7-8129-e7747aacba7b" /> |  

 | HedgeToast |
 | :-----: | 
 | <img width="270" height="189" alt="image" src="https://github.com/user-attachments/assets/99b22e74-bcb3-4d06-9cd5-a537caea9405" /> |  

 | HedgeTextField |
 | :-----: | 
 | <img width="208" height="176" alt="image" src="https://github.com/user-attachments/assets/1eedd26c-c550-471a-94c4-bd967e68f63d" /> |  
 

[NM5-11]: https://depromeet05.atlassian.net/browse/NM5-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ