### PR TITLE
[Fix]create retrospection api

### DIFF
--- a/core/data/src/main/java/com/depromeet/team5/core/data/datasource/RemoteDataSource.kt
+++ b/core/data/src/main/java/com/depromeet/team5/core/data/datasource/RemoteDataSource.kt
@@ -3,10 +3,8 @@ package com.depromeet.team5.core.data.datasource
 import com.depromeet.team5.core.data.model.FeedbackData
 import com.depromeet.team5.core.data.model.MyPrincipleGroupData
 import com.depromeet.team5.core.data.model.MyPrincipleGroupsInfoData
-import com.depromeet.team5.core.data.model.RetrospectionData
 import com.depromeet.team5.core.data.model.RetrospectionListData
 import com.depromeet.team5.core.data.model.SearchData
-import com.depromeet.team5.core.data.request.CreateRetrospectionRequestData
 import com.depromeet.team5.core.data.model.SystemPrincipleData
 import com.depromeet.team5.core.data.model.UserStatsData
 
@@ -14,8 +12,6 @@ import com.depromeet.team5.core.data.model.UserStatsData
 interface RemoteDataSource {
 
     suspend fun search(query: String): SearchData
-
-    suspend fun createRetrospection(request: CreateRetrospectionRequestData): RetrospectionData
 
     suspend fun createFeedback(retrospectionId: Int): FeedbackData
 
@@ -28,12 +24,6 @@ interface RemoteDataSource {
     suspend fun deletePrinciple(principleId: Int)
 
     suspend fun createPrincipleGroup(body: Map<String, Any?>): MyPrincipleGroupData
-
-    suspend fun uploadImageUri(
-        domain: String,
-        uri: String,
-        fileName: String? = null
-    ): Int
 
     suspend fun userStats(): UserStatsData
 

--- a/core/data/src/main/java/com/depromeet/team5/core/data/datasource/RetrospectionRemoteDataSource.kt
+++ b/core/data/src/main/java/com/depromeet/team5/core/data/datasource/RetrospectionRemoteDataSource.kt
@@ -3,13 +3,22 @@ package com.depromeet.team5.core.data.datasource
 import com.depromeet.team5.core.data.model.BaseData
 import com.depromeet.team5.core.data.model.MemoData
 import com.depromeet.team5.core.data.model.RetrospectionData
+import com.depromeet.team5.core.data.request.CreateRetrospectionRequestData
 
 
 interface RetrospectionRemoteDataSource {
 
+    suspend fun createRetrospection(request: CreateRetrospectionRequestData): BaseData<RetrospectionData>
+
     suspend fun getRetrospection(retrospectionId: Int): BaseData<RetrospectionData>
 
     suspend fun deleteRetrospection(retrospectionId: Int): BaseData<String>
+
+    suspend fun uploadImageUri(
+        domain: String,
+        uri: String,
+        fileName: String? = null
+    ): Int
 
     suspend fun createMemo(
         retrospectionId: Int,

--- a/core/data/src/main/java/com/depromeet/team5/core/data/repositoryimpl/HedgeRepositoryImpl.kt
+++ b/core/data/src/main/java/com/depromeet/team5/core/data/repositoryimpl/HedgeRepositoryImpl.kt
@@ -1,16 +1,13 @@
 package com.depromeet.team5.core.data.repositoryimpl
 
 import com.depromeet.team5.core.data.datasource.RemoteDataSource
-import com.depromeet.team5.core.data.mapper.toData
 import com.depromeet.team5.core.domain.model.Feedback
 import com.depromeet.team5.core.domain.model.MyPrincipleGroup
-import com.depromeet.team5.core.domain.model.Retrospection
 import com.depromeet.team5.core.domain.model.RetrospectionList
 import com.depromeet.team5.core.domain.model.Search
 import com.depromeet.team5.core.domain.model.SystemPrinciple
 import com.depromeet.team5.core.domain.model.UserStats
 import com.depromeet.team5.core.domain.repository.HedgeRepository
-import com.depromeet.team5.core.domain.request.CreateRetrospectionRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -23,10 +20,6 @@ internal class HedgeRepositoryImpl @Inject constructor(
 
     override fun search(query: String): Flow<Search> = flow {
         emit(remoteDataSource.search(query).toDomain())
-    }
-
-    override fun createRetrospection(request: CreateRetrospectionRequest): Flow<Retrospection> = flow {
-        emit(remoteDataSource.createRetrospection(request.toData()).toDomain())
     }
 
     override fun createFeedback(
@@ -56,12 +49,6 @@ internal class HedgeRepositoryImpl @Inject constructor(
         emit(remoteDataSource.createPrincipleGroup(body))
     }
         .map { it.toDomain() }
-
-    override suspend fun uploadImageUri(
-        domain: String,
-        uri: String,
-        fileName: String?
-    ): Int = remoteDataSource.uploadImageUri(domain, uri, fileName)
 
     override fun userStats(): Flow<UserStats> = flow {
         emit(remoteDataSource.userStats().toDomain())

--- a/core/data/src/main/java/com/depromeet/team5/core/data/repositoryimpl/RetrospectionRepositoryImpl.kt
+++ b/core/data/src/main/java/com/depromeet/team5/core/data/repositoryimpl/RetrospectionRepositoryImpl.kt
@@ -1,10 +1,12 @@
 package com.depromeet.team5.core.data.repositoryimpl
 
 import com.depromeet.team5.core.data.datasource.RetrospectionRemoteDataSource
+import com.depromeet.team5.core.data.mapper.toData
 import com.depromeet.team5.core.domain.model.BaseDomain
 import com.depromeet.team5.core.domain.model.Memo
 import com.depromeet.team5.core.domain.model.Retrospection
 import com.depromeet.team5.core.domain.repository.RetrospectionRepository
+import com.depromeet.team5.core.domain.request.CreateRetrospectionRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -14,9 +16,20 @@ internal class RetrospectionRepositoryImpl @Inject constructor(
     private val retrospectionRemoteDataSource: RetrospectionRemoteDataSource,
 ) : RetrospectionRepository {
 
+    override fun createRetrospection(request: CreateRetrospectionRequest): Flow<BaseDomain<Retrospection>> = flow {
+        emit(retrospectionRemoteDataSource.createRetrospection(request.toData()).toBaseDomain())
+    }
+
     override fun getRetrospection(retrospectionId: Int): Flow<BaseDomain<Retrospection>> = flow {
         emit(retrospectionRemoteDataSource.getRetrospection(retrospectionId).toBaseDomain())
     }
+
+    override suspend fun uploadImageUri(
+        domain: String,
+        uri: String,
+        fileName: String?
+    ): Int = retrospectionRemoteDataSource.uploadImageUri(domain, uri, fileName)
+
 
     override fun deleteRetrospection(retrospectionId: Int): Flow<BaseDomain<String>> = flow {
         emit(retrospectionRemoteDataSource.deleteRetrospection(retrospectionId).toBaseDomain())

--- a/core/domain/src/main/java/com/depromeet/team5/core/domain/repository/HedgeRepository.kt
+++ b/core/domain/src/main/java/com/depromeet/team5/core/domain/repository/HedgeRepository.kt
@@ -2,10 +2,8 @@ package com.depromeet.team5.core.domain.repository
 
 import com.depromeet.team5.core.domain.model.Feedback
 import com.depromeet.team5.core.domain.model.MyPrincipleGroup
-import com.depromeet.team5.core.domain.model.Retrospection
 import com.depromeet.team5.core.domain.model.RetrospectionList
 import com.depromeet.team5.core.domain.model.Search
-import com.depromeet.team5.core.domain.request.CreateRetrospectionRequest
 import com.depromeet.team5.core.domain.model.SystemPrinciple
 import com.depromeet.team5.core.domain.model.UserStats
 import kotlinx.coroutines.flow.Flow
@@ -14,8 +12,6 @@ import kotlinx.coroutines.flow.Flow
 interface HedgeRepository {
 
     fun search(query: String): Flow<Search>
-
-    fun createRetrospection(request: CreateRetrospectionRequest): Flow<Retrospection>
 
     fun createFeedback(
         retrospectionId: Int
@@ -30,12 +26,6 @@ interface HedgeRepository {
     fun deletePrinciple(principleId: Int): Flow<Unit>
 
     fun createPrincipleGroup(body: Map<String, Any?>): Flow<MyPrincipleGroup>
-
-    suspend fun uploadImageUri(
-        domain: String,
-        uri: String,
-        fileName: String? = null
-    ): Int
 
     fun userStats(): Flow<UserStats>
 

--- a/core/domain/src/main/java/com/depromeet/team5/core/domain/repository/RetrospectionRepository.kt
+++ b/core/domain/src/main/java/com/depromeet/team5/core/domain/repository/RetrospectionRepository.kt
@@ -3,14 +3,23 @@ package com.depromeet.team5.core.domain.repository
 import com.depromeet.team5.core.domain.model.BaseDomain
 import com.depromeet.team5.core.domain.model.Memo
 import com.depromeet.team5.core.domain.model.Retrospection
+import com.depromeet.team5.core.domain.request.CreateRetrospectionRequest
 import kotlinx.coroutines.flow.Flow
 
 
 interface RetrospectionRepository {
 
+    fun createRetrospection(request: CreateRetrospectionRequest): Flow<BaseDomain<Retrospection>>
+
     fun getRetrospection(retrospectionId: Int): Flow<BaseDomain<Retrospection>>
 
     fun deleteRetrospection(retrospectionId: Int): Flow<BaseDomain<String>>
+
+    suspend fun uploadImageUri(
+        domain: String,
+        uri: String,
+        fileName: String? = null
+    ): Int
 
     fun createMemo(
         retrospectionId: Int,

--- a/core/domain/src/main/java/com/depromeet/team5/core/domain/usecase/CreateRetrospectionUseCase.kt
+++ b/core/domain/src/main/java/com/depromeet/team5/core/domain/usecase/CreateRetrospectionUseCase.kt
@@ -1,8 +1,9 @@
 package com.depromeet.team5.core.domain.usecase
 
+import com.depromeet.team5.core.domain.model.BaseDomain
 import com.depromeet.team5.core.domain.model.PrincipleState
 import com.depromeet.team5.core.domain.model.Retrospection
-import com.depromeet.team5.core.domain.repository.HedgeRepository
+import com.depromeet.team5.core.domain.repository.RetrospectionRepository
 import com.depromeet.team5.core.domain.request.CreateRetrospectionRequest
 import com.depromeet.team5.core.domain.request.PrincipleCheckRequest
 import kotlinx.coroutines.Dispatchers
@@ -12,13 +13,13 @@ import javax.inject.Inject
 
 
 class CreateRetrospectionUseCase @Inject constructor(
-    private val hedgeRepository: HedgeRepository,
+    private val retrospectionRepository: RetrospectionRepository,
     private val updateImageUrisUseCase: UpdateImageUrisUseCase
 ) {
     suspend operator fun invoke(
         request: CreateRetrospectionRequest,
         principles: List<PrincipleState>,
-    ): Flow<Retrospection> = withContext(Dispatchers.IO) {
+    ): Flow<BaseDomain<Retrospection>> = withContext(Dispatchers.IO) {
         val principleChecks = principles.map {
             PrincipleCheckRequest(
                 principleId = it.id,
@@ -34,6 +35,6 @@ class CreateRetrospectionUseCase @Inject constructor(
                 links = it.principleChecks.links
             )
         }
-        hedgeRepository.createRetrospection(request.copy(principleChecks = principleChecks))
+        retrospectionRepository.createRetrospection(request.copy(principleChecks = principleChecks))
     }
 }

--- a/core/domain/src/main/java/com/depromeet/team5/core/domain/usecase/UpdateImageUrisUseCase.kt
+++ b/core/domain/src/main/java/com/depromeet/team5/core/domain/usecase/UpdateImageUrisUseCase.kt
@@ -1,6 +1,6 @@
 package com.depromeet.team5.core.domain.usecase
 
-import com.depromeet.team5.core.domain.repository.HedgeRepository
+import com.depromeet.team5.core.domain.repository.RetrospectionRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -8,7 +8,7 @@ import javax.inject.Inject
 
 
 class UpdateImageUrisUseCase @Inject constructor(
-    private val hedgeRepository: HedgeRepository
+    private val retrospectionRepository: RetrospectionRepository
 ) {
     suspend operator fun invoke(
         domain: String,
@@ -18,7 +18,7 @@ class UpdateImageUrisUseCase @Inject constructor(
         imageUrls
             .map {
                 async {
-                    hedgeRepository.uploadImageUri(
+                    retrospectionRepository.uploadImageUri(
                         domain = domain,
                         uri = it,
                         fileName = fileName

--- a/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/RemoteDataSourceImpl.kt
+++ b/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/RemoteDataSourceImpl.kt
@@ -5,14 +5,11 @@ import com.depromeet.team5.core.data.datasource.RemoteDataSource
 import com.depromeet.team5.core.data.model.FeedbackData
 import com.depromeet.team5.core.data.model.MyPrincipleGroupData
 import com.depromeet.team5.core.data.model.MyPrincipleGroupsInfoData
-import com.depromeet.team5.core.data.model.RetrospectionData
 import com.depromeet.team5.core.data.model.RetrospectionListData
 import com.depromeet.team5.core.data.model.SearchData
-import com.depromeet.team5.core.data.request.CreateRetrospectionRequestData
 import com.depromeet.team5.core.data.model.SystemPrincipleData
 import com.depromeet.team5.core.data.model.UserStatsData
 import com.depromeet.team5.core.remotedatasource.apisource.HedgeApiSource
-import com.depromeet.team5.core.remotedatasource.mapper.toRemoteData
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -24,19 +21,6 @@ internal class RemoteDataSourceImpl @Inject constructor(
 
     override suspend fun search(query: String): SearchData =
         hedgeApiSource.search(query).toData()
-
-    override suspend fun createRetrospection(request: CreateRetrospectionRequestData): RetrospectionData =
-        hedgeApiSource.createRetrospection(request.toRemoteData()).toData()
-
-    override suspend fun uploadImageUri(
-        domain: String,
-        uri: String,
-        fileName: String?
-    ) = hedgeApiSource.uploadImageUri(
-        domain = domain,
-        uri = uri.toUri(),
-        fileName = fileName
-    )
 
     override suspend fun createFeedback(retrospectionId: Int): FeedbackData =
         hedgeApiSource.createFeedback(retrospectionId).toData()

--- a/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/apisource/HedgeApiSource.kt
+++ b/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/apisource/HedgeApiSource.kt
@@ -1,22 +1,17 @@
 package com.depromeet.team5.core.remotedatasource.apisource
 
-import android.net.Uri
 import com.depromeet.team5.core.remotedatasource.model.FeedbackRemoteData
 import com.depromeet.team5.core.remotedatasource.model.MyPrincipleGroupRemoteData
 import com.depromeet.team5.core.remotedatasource.model.MyPrincipleGroupsInfoRemoteData
 import com.depromeet.team5.core.remotedatasource.model.RetrospectionListRemoteData
-import com.depromeet.team5.core.remotedatasource.model.RetrospectionRemoteData
 import com.depromeet.team5.core.remotedatasource.model.SearchRemoteData
 import com.depromeet.team5.core.remotedatasource.model.SystemPrincipleRemoteData
 import com.depromeet.team5.core.remotedatasource.model.UserStatsRemoteData
-import com.depromeet.team5.core.remotedatasource.request.CreateRetrospectionRequestRemoteData
 
 
 interface HedgeApiSource {
 
     suspend fun search(query: String): SearchRemoteData
-
-    suspend fun createRetrospection(request: CreateRetrospectionRequestRemoteData): RetrospectionRemoteData
 
     suspend fun createFeedback(retrospectionId: Int): FeedbackRemoteData
 
@@ -29,12 +24,6 @@ interface HedgeApiSource {
     suspend fun deletePrinciple(principleId: Int)
 
     suspend fun createPrincipleGroup(body: Map<String, Any?>): MyPrincipleGroupRemoteData
-
-    suspend fun uploadImageUri(
-        domain: String,
-        uri: Uri,
-        fileName: String? = null
-    ): Int
 
     suspend fun userStats(): UserStatsRemoteData
 

--- a/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/apisource/RetrospectionApiSource.kt
+++ b/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/apisource/RetrospectionApiSource.kt
@@ -1,15 +1,25 @@
 package com.depromeet.team5.core.remotedatasource.apisource
 
+import android.net.Uri
 import com.depromeet.team5.core.remotedatasource.model.BaseRemoteData
 import com.depromeet.team5.core.remotedatasource.model.MemoRemoteData
 import com.depromeet.team5.core.remotedatasource.model.RetrospectionRemoteData
+import com.depromeet.team5.core.remotedatasource.request.CreateRetrospectionRequestRemoteData
 
 
 interface RetrospectionApiSource {
 
+    suspend fun createRetrospection(request: CreateRetrospectionRequestRemoteData): BaseRemoteData<RetrospectionRemoteData>
+
     suspend fun getRetrospection(retrospectionId: Int): BaseRemoteData<RetrospectionRemoteData>
 
     suspend fun deleteRetrospection(retrospectionId: Int): BaseRemoteData<String>
+
+    suspend fun uploadImageUri(
+        domain: String,
+        uri: Uri,
+        fileName: String? = null
+    ): Int
 
     suspend fun createMemo(
         retrospectionId: Int,

--- a/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/datasourceimpl/RetrospectionRemoteDataSourceImpl.kt
+++ b/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/datasourceimpl/RetrospectionRemoteDataSourceImpl.kt
@@ -1,10 +1,13 @@
 package com.depromeet.team5.core.remotedatasource.datasourceimpl
 
+import androidx.core.net.toUri
 import com.depromeet.team5.core.data.datasource.RetrospectionRemoteDataSource
 import com.depromeet.team5.core.data.model.BaseData
 import com.depromeet.team5.core.data.model.MemoData
 import com.depromeet.team5.core.data.model.RetrospectionData
+import com.depromeet.team5.core.data.request.CreateRetrospectionRequestData
 import com.depromeet.team5.core.remotedatasource.apisource.RetrospectionApiSource
+import com.depromeet.team5.core.remotedatasource.mapper.toRemoteData
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,11 +17,24 @@ internal class RetrospectionRemoteDataSourceImpl @Inject constructor(
     private val retrospectionApiSource: RetrospectionApiSource,
 ) : RetrospectionRemoteDataSource {
 
+    override suspend fun createRetrospection(request: CreateRetrospectionRequestData): BaseData<RetrospectionData> =
+        retrospectionApiSource.createRetrospection(request.toRemoteData()).toBaseData()
+
     override suspend fun getRetrospection(retrospectionId: Int): BaseData<RetrospectionData> =
         retrospectionApiSource.getRetrospection(retrospectionId).toBaseData()
 
     override suspend fun deleteRetrospection(retrospectionId: Int): BaseData<String> =
         retrospectionApiSource.deleteRetrospection(retrospectionId).toBaseData()
+
+    override suspend fun uploadImageUri(
+        domain: String,
+        uri: String,
+        fileName: String?
+    ) = retrospectionApiSource.uploadImageUri(
+        domain = domain,
+        uri = uri.toUri(),
+        fileName = fileName
+    )
 
     override suspend fun createMemo(retrospectionId: Int, content: String): BaseData<MemoData> =
         retrospectionApiSource.createMemo(retrospectionId, content).toBaseData()

--- a/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/request/CreateRetrospectionRequestRemoteData.kt
+++ b/core/remotedatasource/src/main/java/com/depromeet/team5/core/remotedatasource/request/CreateRetrospectionRequestRemoteData.kt
@@ -1,5 +1,8 @@
 package com.depromeet.team5.core.remotedatasource.request
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class CreateRetrospectionRequestRemoteData(
     val symbol: String,
     val market: String,
@@ -12,6 +15,7 @@ data class CreateRetrospectionRequestRemoteData(
     val principleChecks: List<PrincipleCheckRequestRemoteData>,
 )
 
+@Serializable
 data class PrincipleCheckRequestRemoteData(
     val principleId: Int,
     val status: String,

--- a/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/api/HedgeApi.kt
+++ b/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/api/HedgeApi.kt
@@ -1,24 +1,17 @@
 package com.depromeet.team5.core.retrofit.api
 
-import com.depromeet.team5.core.remotedatasource.request.CreateRetrospectionRequestRemoteData
-import com.depromeet.team5.core.retrofit.model.BaseResponse
 import com.depromeet.team5.core.retrofit.model.FeedbackResponse
-import com.depromeet.team5.core.retrofit.model.ImageUploadResponse
 import com.depromeet.team5.core.retrofit.model.MyPrincipleGroupInfoResponse
 import com.depromeet.team5.core.retrofit.model.MyPrincipleGroupsInfoResponse
 import com.depromeet.team5.core.retrofit.model.RetrospectionListResponse
-import com.depromeet.team5.core.retrofit.model.RetrospectionResponse
 import com.depromeet.team5.core.retrofit.model.SearchResponse
 import com.depromeet.team5.core.retrofit.model.SystemPrincipleResponse
 import com.depromeet.team5.core.retrofit.model.UserStatsResponse
-import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.Multipart
 import retrofit2.http.POST
-import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -26,9 +19,6 @@ interface HedgeApi {
 
     @GET("api/v1/stock/search")
     suspend fun search(@Query("query") query: String): SearchResponse
-
-    @POST("api/v1/retrospections")
-    suspend fun createRetrospection(@Body body: CreateRetrospectionRequestRemoteData): RetrospectionResponse
 
     @POST("api/v1/reports/{retrospectionId}/feedback")
     suspend fun createFeedback(
@@ -63,13 +53,6 @@ interface HedgeApi {
     suspend fun createPrincipleGroup(
         @Body body: RequestBody
     ): MyPrincipleGroupInfoResponse
-
-    @Multipart
-    @POST("api/v1/{domain}/images/upload")
-    suspend fun imageUpload(
-        @Path("domain") domain: String,
-        @Part file: MultipartBody.Part,
-    ): BaseResponse<ImageUploadResponse>
 
     @GET("api/v1/reports")
     suspend fun userStats(): UserStatsResponse

--- a/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/api/RetrospectionApi.kt
+++ b/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/api/RetrospectionApi.kt
@@ -1,16 +1,24 @@
 package com.depromeet.team5.core.retrofit.api
 
+import com.depromeet.team5.core.remotedatasource.request.CreateRetrospectionRequestRemoteData
 import com.depromeet.team5.core.retrofit.model.BaseResponse
+import com.depromeet.team5.core.retrofit.model.ImageUploadResponse
 import com.depromeet.team5.core.retrofit.model.MemoResponse
 import com.depromeet.team5.core.retrofit.model.RetrospectionResponse
+import okhttp3.MultipartBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.PUT
+import retrofit2.http.Part
 import retrofit2.http.Path
 
 interface RetrospectionApi {
+
+    @POST(PATH)
+    suspend fun createRetrospection(@Body body: CreateRetrospectionRequestRemoteData): BaseResponse<RetrospectionResponse>
 
     @GET("$PATH/{retrospectionId}")
     suspend fun getRetrospection(
@@ -21,6 +29,13 @@ interface RetrospectionApi {
     suspend fun deleteRetrospection(
         @Path("retrospectionId") retrospectionId: Int,
     ): BaseResponse<String>
+
+    @Multipart
+    @POST("api/v1/{domain}/images/upload")
+    suspend fun imageUpload(
+        @Path("domain") domain: String,
+        @Part file: MultipartBody.Part,
+    ): BaseResponse<ImageUploadResponse>
 
     @POST("$PATH/{retrospectionId}/memos")
     suspend fun createMemo(

--- a/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/apisourceimpl/HedgeApiSourceImpl.kt
+++ b/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/apisourceimpl/HedgeApiSourceImpl.kt
@@ -1,23 +1,15 @@
 package com.depromeet.team5.core.retrofit.apisourceimpl
 
-import android.content.Context
-import android.net.Uri
 import com.depromeet.team5.core.remotedatasource.apisource.HedgeApiSource
 import com.depromeet.team5.core.remotedatasource.model.FeedbackRemoteData
 import com.depromeet.team5.core.remotedatasource.model.MyPrincipleGroupRemoteData
 import com.depromeet.team5.core.remotedatasource.model.MyPrincipleGroupsInfoRemoteData
-import com.depromeet.team5.core.remotedatasource.model.RetrospectionRemoteData
 import com.depromeet.team5.core.remotedatasource.model.RetrospectionListRemoteData
 import com.depromeet.team5.core.remotedatasource.model.SearchRemoteData
-import com.depromeet.team5.core.remotedatasource.request.CreateRetrospectionRequestRemoteData
 import com.depromeet.team5.core.remotedatasource.model.SystemPrincipleRemoteData
 import com.depromeet.team5.core.remotedatasource.model.UserStatsRemoteData
 import com.depromeet.team5.core.retrofit.api.HedgeApi
 import com.depromeet.team5.core.retrofit.toRequestBody
-import dagger.hilt.android.qualifiers.ApplicationContext
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.MultipartBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -25,15 +17,10 @@ import javax.inject.Singleton
 @Singleton
 internal class HedgeApiSourceImpl @Inject constructor(
     private val hedgeApi: HedgeApi,
-    @ApplicationContext private val context: Context
 ) : HedgeApiSource {
 
     override suspend fun search(query: String): SearchRemoteData =
         hedgeApi.search(query = query).toRemoteData()
-
-    override suspend fun createRetrospection(
-        request: CreateRetrospectionRequestRemoteData
-    ): RetrospectionRemoteData = hedgeApi.createRetrospection(request).toRemoteData()
 
     override suspend fun createFeedback(retrospectionId: Int): FeedbackRemoteData = hedgeApi
         .createFeedback(retrospectionId = retrospectionId)
@@ -53,30 +40,6 @@ internal class HedgeApiSourceImpl @Inject constructor(
 
     override suspend fun createPrincipleGroup(body: Map<String, Any?>): MyPrincipleGroupRemoteData =
         hedgeApi.createPrincipleGroup(body.toRequestBody()).toRemoteData()
-
-    override suspend fun uploadImageUri(
-        domain: String,
-        uri: Uri,
-        fileName: String?
-    ): Int {
-        val mime = context.contentResolver.getType(uri) ?: "image/*"
-        val name = fileName ?: guessFileName(mime)
-
-        val bytes = context.contentResolver.openInputStream(uri)!!.use { it.readBytes() }
-        val reqBody = bytes.toRequestBody(mime.toMediaType())
-        val part = MultipartBody.Part.createFormData("file", name, reqBody)
-        return hedgeApi.imageUpload(domain, part).data?.imageId ?: -1
-    }
-
-    private fun guessFileName(mime: String): String {
-        val ext = when {
-            mime.contains("jpeg") -> "jpg"
-            mime.contains("png") -> "png"
-            mime.contains("webp") -> "webp"
-            else -> "bin"
-        }
-        return "image_${System.currentTimeMillis()}.$ext"
-    }
 
     override suspend fun userStats(): UserStatsRemoteData =
         hedgeApi

--- a/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/apisourceimpl/RetrospectionApiSourceImpl.kt
+++ b/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/apisourceimpl/RetrospectionApiSourceImpl.kt
@@ -1,17 +1,29 @@
 package com.depromeet.team5.core.retrofit.apisourceimpl
 
+import android.content.Context
+import android.net.Uri
 import com.depromeet.team5.core.remotedatasource.apisource.RetrospectionApiSource
 import com.depromeet.team5.core.remotedatasource.model.BaseRemoteData
 import com.depromeet.team5.core.remotedatasource.model.MemoRemoteData
 import com.depromeet.team5.core.remotedatasource.model.RetrospectionRemoteData
+import com.depromeet.team5.core.remotedatasource.request.CreateRetrospectionRequestRemoteData
 import com.depromeet.team5.core.retrofit.api.RetrospectionApi
+import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 internal class RetrospectionApiSourceImpl @Inject constructor(
     private val retrospectionApi: RetrospectionApi,
+    @ApplicationContext private val context: Context,
 ) : RetrospectionApiSource {
+
+    override suspend fun createRetrospection(
+        request: CreateRetrospectionRequestRemoteData
+    ): BaseRemoteData<RetrospectionRemoteData> = retrospectionApi.createRetrospection(request).toBaseRemoteData()
 
     override suspend fun getRetrospection(retrospectionId: Int): BaseRemoteData<RetrospectionRemoteData> =
         retrospectionApi
@@ -22,6 +34,20 @@ internal class RetrospectionApiSourceImpl @Inject constructor(
         retrospectionApi
             .deleteRetrospection(retrospectionId)
             .toBaseRemoteData()
+
+    override suspend fun uploadImageUri(
+        domain: String,
+        uri: Uri,
+        fileName: String?
+    ): Int {
+        val mime = context.contentResolver.getType(uri) ?: "image/*"
+        val name = fileName ?: guessFileName(mime)
+
+        val bytes = context.contentResolver.openInputStream(uri)!!.use { it.readBytes() }
+        val reqBody = bytes.toRequestBody(mime.toMediaType())
+        val part = MultipartBody.Part.createFormData("file", name, reqBody)
+        return retrospectionApi.imageUpload(domain, part).data?.imageId ?: -1
+    }
 
     override suspend fun createMemo(retrospectionId: Int, content: String): BaseRemoteData<MemoRemoteData> =
         retrospectionApi
@@ -48,4 +74,13 @@ internal class RetrospectionApiSourceImpl @Inject constructor(
             )
             .toBaseRemoteData()
 
+    private fun guessFileName(mime: String): String {
+        val ext = when {
+            mime.contains("jpeg") -> "jpg"
+            mime.contains("png") -> "png"
+            mime.contains("webp") -> "webp"
+            else -> "bin"
+        }
+        return "image_${System.currentTimeMillis()}.$ext"
+    }
 }

--- a/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/di/ApiModule.kt
+++ b/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/di/ApiModule.kt
@@ -16,13 +16,13 @@ internal object ApiModule {
     @Provides
     @Singleton
     fun provideHedgeApi(
-        retrofit: Retrofit
+        @GsonRetrofit retrofit: Retrofit
     ): HedgeApi = retrofit.create(HedgeApi::class.java)
 
     @Provides
     @Singleton
     fun provideRetrospectionApi(
-        retrofit: Retrofit
+        @SerializationRetrofit retrofit: Retrofit
     ): RetrospectionApi = retrofit.create(RetrospectionApi::class.java)
 
 }

--- a/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/di/ConverterModule.kt
+++ b/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/di/ConverterModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Converter
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
 
@@ -26,7 +27,7 @@ internal object ConverterModule {
     @Singleton
     fun provideConverterFactory(
         json: Json,
-    ) = json.asConverterFactory("application/json".toMediaType())
+    ): Converter.Factory = json.asConverterFactory("application/json".toMediaType())
 
     @Provides
     @Singleton

--- a/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/di/RetrofitModule.kt
+++ b/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/di/RetrofitModule.kt
@@ -6,9 +6,20 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
+import retrofit2.Converter
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class GsonRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class SerializationRetrofit
+
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -16,9 +27,24 @@ internal object RetrofitModule {
 
     @Singleton
     @Provides
-    fun provideRetrofit(
+    @GsonRetrofit
+    fun provideGsonRetrofit(
         okHttpClient: OkHttpClient,
-        converterFactory: GsonConverterFactory,
+        gsonConverterFactory: GsonConverterFactory,
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(gsonConverterFactory)
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    @SerializationRetrofit
+    fun provideSerializationRetrofit(
+        okHttpClient: OkHttpClient,
+        converterFactory: Converter.Factory,
     ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.BASE_URL)

--- a/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/model/RetrospectionResponse.kt
+++ b/core/retrofit/src/main/java/com/depromeet/team5/core/retrofit/model/RetrospectionResponse.kt
@@ -12,16 +12,16 @@ data class RetrospectionResponse(
     val id: Int,
     val userId: Int,
     val market: String,
-    val price: Int,
+    val price: Double,
     val createdAt: String,
     val currency: String,
     val orderDate: String,
     val orderType: String,
-    val returnRate: Double?,
+    val returnRate: Double? = null,
     val symbol: String,
     val updatedAt: String,
     val volume: Int,
-    val principleCheckGroups: PrincipleCheckGroupsResponse? = null,
+    val principleCheckGroup: PrincipleCheckGroupsResponse? = null,
     val memos: List<MemoResponse> = emptyList(),
 ) : RetrofitMapper<RetrospectionRemoteData> {
 
@@ -32,13 +32,13 @@ data class RetrospectionResponse(
         market = market,
         orderDate = orderDate,
         orderType = orderType,
-        price = price,
+        price = price.toInt(),
         returnRate = returnRate ?: 0.0,
         symbol = symbol,
         updatedAt = updatedAt,
         userId = userId,
         volume = volume,
-        principleCheckGroupsRemoteData = principleCheckGroups?.toRemoteData(),
+        principleCheckGroupsRemoteData = principleCheckGroup?.toRemoteData(),
         memos = memos.map { it.toRemoteData() },
     )
 }
@@ -83,6 +83,7 @@ data class PrincipleCheckResponse(
 data class MemoResponse(
     val memoId: Int,
     val content: String,
+    val createdAt: String,
 ) : RetrofitMapper<MemoRemoteData> {
     override fun toRemoteData() = MemoRemoteData(
         memoId = memoId,

--- a/features/feedback/src/main/java/com/depromeet/team5/features/feedback/screen/AiFeedbackViewModel.kt
+++ b/features/feedback/src/main/java/com/depromeet/team5/features/feedback/screen/AiFeedbackViewModel.kt
@@ -40,7 +40,7 @@ class AiFeedbackViewModel @Inject constructor(
                 request = request.copy(orderDate = formatDate(request.orderDate)),
                 principles = principleGroupState.principles,
             )
-                .flatMapConcat { createFeedbackUseCase(it.id) }
+                .flatMapConcat { createFeedbackUseCase(it.data!!.id) }
                 .map {
                     if (it.data != null) {
                         AiFeedbackUiState.Success(


### PR DESCRIPTION
- 회고 생성 플로우가 안 돼서 민서가 테스트를 못 하고 있다해서 요거 먼저 수정했슴다.
- Retrofit Converter 분리, Retrospection 관련 api migration한 거 밖에 없으니 바로 머지하께용~
- data ~ retrofit layer의 HedgeXXX에 컨플릭트 날 수 있는데 그냥 함수 옮긴 거라 ㅎ.ㅎ