### PR TITLE
[fix]스테이터스바 light mode 고정으로 컬러 대응

### DIFF
--- a/app/src/main/java/com/depromeet/team5/MainActivity.kt
+++ b/app/src/main/java/com/depromeet/team5/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.depromeet.team5
 
+import android.graphics.Color.TRANSPARENT
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.remember
@@ -29,7 +31,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.light(TRANSPARENT, TRANSPARENT))
         setContent {
             DepromeetTheme {
                 val context = LocalContext.current


### PR DESCRIPTION
휴대폰이 다크모드일 때 스테이터스바 아이콘이 잘 보이지 않던 이슈를 해결합니다.