### PR TITLE
[Fix] NM5-46 홈화면 수정

### DIFF
--- a/core/ui/src/main/java/com/depromeet/team5/core/ui/component/PrincipleThumbnail.kt
+++ b/core/ui/src/main/java/com/depromeet/team5/core/ui/component/PrincipleThumbnail.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -30,6 +31,7 @@ fun PrincipleThumbnail(
                 contentDescription = null,
                 modifier = Modifier
                     .padding(end = 4.dp)
+                    .clip(shape = CircleShape)
                     .size(32.dp),
                 contentScale = ContentScale.Crop
             )

--- a/features/home/src/main/java/com/depromeet/team5/features/home/component/HomeFloatingActionButton.kt
+++ b/features/home/src/main/java/com/depromeet/team5/features/home/component/HomeFloatingActionButton.kt
@@ -6,13 +6,16 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,14 +25,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.depromeet.team5.core.designsystem.foundation.HedgeColor
 import com.depromeet.team5.core.designsystem.foundation.HedgeTypography
+import com.depromeet.team5.core.domain.model.OrderType
 import com.depromeet.team5.features.home.R
 
 @Composable
@@ -54,7 +56,8 @@ fun HomeFloatingActionButton(
             .fillMaxSize()
     ) {
         Column(
-            modifier = Modifier.align(Alignment.BottomEnd),
+            modifier = Modifier
+                .align(Alignment.BottomEnd),
             horizontalAlignment = Alignment.End
         ) {
             if (fabChecked)
@@ -65,32 +68,36 @@ fun HomeFloatingActionButton(
                             color = HedgeColor.Neutral.BackgroundDefault,
                             shape = RoundedCornerShape(18.dp)
                         )
+                        .width(IntrinsicSize.Max)
                 ) {
                     FABItem(
                         interaction = interaction,
                         onClick = onBuyClick,
-                        itemTitle = stringResource(R.string.home_buy_button),
-                        itemIconColor = HedgeColor.Trade.Buy,
-                        itemIconBackgroundColor = Color(0xFFFFEBED),
+                        itemTitle = OrderType.BUY.toKorean(),
+                        itemColor = HedgeColor.Trade.Buy,
                         modifier = Modifier.padding(
-                            start = 14.dp,
-                            end = 14.dp,
-                            top = 14.dp,
-                            bottom = 8.dp
+                            start = 24.dp,
+                            end = 24.dp,
+                            top = 16.dp,
+                            bottom = 12.dp
                         )
+                    )
+
+                    Divider(
+                        thickness = 1.dp,
+                        color = HedgeColor.Neutral.BackgroundSecondary
                     )
 
                     FABItem(
                         interaction = interaction,
                         onClick = onSellClick,
-                        itemTitle = stringResource(R.string.home_sell_button),
-                        itemIconColor = HedgeColor.Trade.Sell,
-                        itemIconBackgroundColor = Color(0xFFEAF4FF),
+                        itemTitle = OrderType.SELL.toKorean(),
+                        itemColor = HedgeColor.Trade.Sell,
                         modifier = Modifier.padding(
-                            start = 14.dp,
-                            end = 14.dp,
-                            top = 8.dp,
-                            bottom = 14.dp
+                            start = 24.dp,
+                            end = 24.dp,
+                            top = 12.dp,
+                            bottom = 16.dp
                         )
                     )
                 }
@@ -128,8 +135,7 @@ private fun FABItem(
     interaction: MutableInteractionSource,
     onClick: () -> Unit,
     itemTitle: String,
-    itemIconColor: Color,
-    itemIconBackgroundColor: Color,
+    itemColor: Color,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -142,19 +148,15 @@ private fun FABItem(
             },
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_pencil),
-            contentDescription = null,
-            tint = itemIconColor,
-            modifier = Modifier
-                .padding(end = 8.dp)
-                .background(color = itemIconBackgroundColor, shape = RoundedCornerShape(10.dp))
-                .padding(7.dp)
-                .size(14.dp)
+        Text(
+            text = itemTitle,
+            style = HedgeTypography.Body2.SemiBold,
+            color = itemColor,
+            modifier = Modifier.padding(end = 4.dp)
         )
 
         Text(
-            text = itemTitle,
+            text = stringResource(R.string.home_buy_sell_button),
             style = HedgeTypography.Body2.SemiBold,
             color = HedgeColor.Text.Primary,
         )

--- a/features/home/src/main/java/com/depromeet/team5/features/home/component/OrderTypeButton.kt
+++ b/features/home/src/main/java/com/depromeet/team5/features/home/component/OrderTypeButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.depromeet.team5.core.designsystem.foundation.HedgeColor
@@ -28,6 +29,7 @@ fun OrderTypeButton(
                 color = if (isSelected) HedgeColor.Text.Title else HedgeColor.Neutral.BackgroundSecondary,
                 shape = RoundedCornerShape(100.dp)
             )
+            .clip(RoundedCornerShape(100.dp))
             .clickable(onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 6.dp)
     )

--- a/features/home/src/main/java/com/depromeet/team5/features/home/component/RecommendPrincipleItem.kt
+++ b/features/home/src/main/java/com/depromeet/team5/features/home/component/RecommendPrincipleItem.kt
@@ -45,13 +45,13 @@ fun RecommendPrincipleItem(
                 spotColor = Color(0x140D0F26),
                 clip = false
             )
-            .clickable { onClick(recommendPrinciple.id) }
             .background(
                 color = HedgeColor.Neutral.BackgroundDefault,
                 shape = RoundedCornerShape(18.dp)
             )
             .border(width = 1.dp, color = Color(0xFFF1F2F4), shape = RoundedCornerShape(18.dp))
             .clip(RoundedCornerShape(18.dp))
+            .clickable { onClick(recommendPrinciple.id) }
             .size(150.dp, 165.dp)
     ) {
         Box(

--- a/features/home/src/main/java/com/depromeet/team5/features/home/component/RetrospectionMasterDetail.kt
+++ b/features/home/src/main/java/com/depromeet/team5/features/home/component/RetrospectionMasterDetail.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
@@ -33,6 +34,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.depromeet.team5.core.designsystem.foundation.HedgeColor
 import com.depromeet.team5.core.designsystem.foundation.HedgeTypography
+import com.depromeet.team5.core.ui.component.HedgeCompanyLogo
 import com.depromeet.team5.features.home.R
 import com.depromeet.team5.features.home.screen.RetrospectionSectionState
 import com.depromeet.team5.features.home.screen.RetrospectionState
@@ -74,6 +76,7 @@ fun RetrospectionMasterDetail(
                 ) { item ->
                     SymbolRailItem(
                         symbol = item.companyName,
+                        logoUrl = item.image,
                         selected = item.companyName == selectedCompanyName,
                         onClick = { selectedCompanyName = item.companyName }
                     )
@@ -113,6 +116,7 @@ fun RetrospectionMasterDetail(
 @Composable
 private fun SymbolRailItem(
     symbol: String,
+    logoUrl: String?,
     selected: Boolean,
     onClick: () -> Unit,
 ) {
@@ -128,11 +132,11 @@ private fun SymbolRailItem(
             .padding(vertical = 10.dp, horizontal = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
-            Modifier
+        HedgeCompanyLogo(
+            logoUrl = logoUrl,
+            modifier = Modifier
+                .clip(shape = CircleShape)
                 .size(24.dp)
-                .clip(RoundedCornerShape(100.dp))
-                .background(HedgeColor.GREY_600)
         )
         Spacer(Modifier.width(8.dp))
         Text(
@@ -142,6 +146,7 @@ private fun SymbolRailItem(
             maxLines = 2
         )
     }
+
 }
 
 @Composable

--- a/features/home/src/main/java/com/depromeet/team5/features/home/screen/HomeViewModel.kt
+++ b/features/home/src/main/java/com/depromeet/team5/features/home/screen/HomeViewModel.kt
@@ -49,6 +49,9 @@ enum class HomeTab(
 
 data class RetrospectionSymbolState(
     val companyName: String,
+    val image: String?,
+    val symbol: String,
+    val market: String,
     val sections: List<RetrospectionSectionState>,
 )
 
@@ -124,6 +127,9 @@ class HomeViewModel @Inject constructor(
                             }
                         RetrospectionSymbolState(
                             companyName = companyName.companyName,
+                            image = companyName.image,
+                            symbol = companyName.symbol,
+                            market = companyName.market,
                             sections = sections
                         )
                     }

--- a/features/home/src/main/java/com/depromeet/team5/features/home/section/HomeSection.kt
+++ b/features/home/src/main/java/com/depromeet/team5/features/home/section/HomeSection.kt
@@ -358,8 +358,20 @@ private fun HomeSectionPreview() {
 
     val successList = HedgeUiState.Success(
         listOf(
-            RetrospectionSymbolState(companyName = "삼성전자", sections = sampleSections),
-            RetrospectionSymbolState(companyName = "애플", sections = sampleSections)
+            RetrospectionSymbolState(
+                companyName = "삼성전자",
+                sections = sampleSections,
+                image = null,
+                symbol = "",
+                market = ""
+            ),
+            RetrospectionSymbolState(
+                companyName = "애플",
+                sections = sampleSections,
+                image = null,
+                symbol = "",
+                market = ""
+            )
         )
     )
 

--- a/features/home/src/main/java/com/depromeet/team5/features/home/section/PrincipleSection.kt
+++ b/features/home/src/main/java/com/depromeet/team5/features/home/section/PrincipleSection.kt
@@ -9,11 +9,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -190,18 +192,26 @@ fun PrincipleSection(
 
         when (val ui = principleGroupsUiState) {
             is HedgeUiState.Success -> {
-                ui.data.forEach { group ->
-                    PrincipleItem(
-                        id = group.id,
-                        icon = group.thumbnail,
-                        title = group.groupName,
-                        onClick = {
-                            onClickPrincipleDetail(
-                                group.id,
-                                Path.PRINCIPLE_MINE
-                            )
-                        }
-                    )
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize()
+                ){
+                    items(
+                        items = ui.data,
+                        key = { it.id }
+                    ){ group ->
+                        PrincipleItem(
+                            id = group.id,
+                            icon = group.thumbnail,
+                            title = group.groupName,
+                            onClick = {
+                                onClickPrincipleDetail(
+                                    group.id,
+                                    Path.PRINCIPLE_MINE
+                                )
+                            }
+                        )
+
+                    }
                 }
             }
 

--- a/features/home/src/main/res/values/strings.xml
+++ b/features/home/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
-    <string name="home_buy_button">매수 회고하기</string>
-    <string name="home_sell_button">매도 회고하기</string>
+    <string name="home_buy_sell_button">회고하기</string>
     <string name="home_tab_title_home">홈</string>
     <string name="home_tab_title_principle">원칙</string>
 

--- a/features/login/src/main/java/com/depromeet/team5/features/login/AgreementsScreen.kt
+++ b/features/login/src/main/java/com/depromeet/team5/features/login/AgreementsScreen.kt
@@ -141,28 +141,32 @@ private fun AgreementRow(
             .padding(vertical = if (variant == AgreementRowVariant.All) 22.dp else 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Icon(
-            imageVector = if (checked) HedgeIcon.AgreementChecked else HedgeIcon.AgreementUnchecked,
-            contentDescription = null,
+        Row(
             modifier = Modifier
-                .padding(end = 14.dp)
+                .weight(1f)
                 .clickable(
                     interactionSource = checkInteraction,
                     indication = null
                 ) {
                     onCheckedChange(!checked)
                 },
-            tint = Color.Unspecified
-        )
+            verticalAlignment = Alignment.CenterVertically
+        ){
+            Icon(
+                imageVector = if (checked) HedgeIcon.AgreementChecked else HedgeIcon.AgreementUnchecked,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 14.dp),
+                tint = Color.Unspecified
+            )
 
-        Text(
-            text = title,
-            style = if (variant == AgreementRowVariant.All) HedgeTypography.Body1.SemiBold else HedgeTypography.Body3.Medium,
-            color = HedgeColor.Text.Secondary,
-        )
+            Text(
+                text = title,
+                style = if (variant == AgreementRowVariant.All) HedgeTypography.Body1.SemiBold else HedgeTypography.Body3.Medium,
+                color = HedgeColor.Text.Secondary
+            )
+        }
 
         if (link != null) {
-            Spacer(modifier = Modifier.weight(1f))
             Icon(
                 imageVector = HedgeIcon.ArrowRightThin,
                 contentDescription = null,

--- a/features/login/src/main/java/com/depromeet/team5/features/login/AgreementsScreen.kt
+++ b/features/login/src/main/java/com/depromeet/team5/features/login/AgreementsScreen.kt
@@ -112,7 +112,7 @@ private fun AgreementsScreen(
             text = stringResource(R.string.agreements_start_button),
             onClick = navigateToHome,
             modifier = Modifier
-                .padding(horizontal = 20.dp)
+                .padding(horizontal = 20.dp, vertical = 20.dp)
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter),
             enabled = state.canProceed,

--- a/features/login/src/main/java/com/depromeet/team5/features/login/LoginScreen.kt
+++ b/features/login/src/main/java/com/depromeet/team5/features/login/LoginScreen.kt
@@ -116,6 +116,7 @@ private fun LoginScreen(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(bottom = 20.dp)
                 .padding(20.dp)
                 .clip(RoundedCornerShape(18.dp))
                 .background(color = Color(0xFFFEE500))


### PR DESCRIPTION
### 변경사항 요약
#### 홈탭
- 회고 등록하기 - 매수,매도 회고하기 버튼 수정
- 회고 - 2줄 max
- 회고 - 기본 이미지 추가
- 회고 - 서버 응답 수정에 따른 반영

#### 원칙탭
- 내 원칙 리스트 - LazyColumn
- 매수/매도 리플 클립
- 추천원칙 리플 클립
- 원칙그룹 썸네일 Circle crop

#### 이용약관탭
- cta 버튼 → 디자인시스템 cta 버튼 교체
- 체크 클릭 영역 수정



https://github.com/user-attachments/assets/28d5c55c-f2a3-4d01-88fb-5ddc4380d341

