### PR TITLE
[Fix] company logo issue

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     api(projects.core.designsystem)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.okhttp)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/features/home/build.gradle.kts
+++ b/features/home/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(projects.core.navigation)
     implementation(projects.core.ui)
     implementation(projects.core.domain)
-
     implementation(libs.coil.compose)
+    implementation(libs.coil.okhttp)
+
 }

--- a/features/principlegroupdetail/build.gradle.kts
+++ b/features/principlegroupdetail/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(projects.core.ui)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.okhttp)
 
     implementation(libs.org.jetbrains.kotlinx.kotlinx.serialization.json)
 }

--- a/features/principlemodification/build.gradle.kts
+++ b/features/principlemodification/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(projects.core.ui)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.okhttp)
 
     implementation(libs.org.jetbrains.kotlinx.kotlinx.serialization.json)
 }

--- a/features/reasons/build.gradle.kts
+++ b/features/reasons/build.gradle.kts
@@ -29,5 +29,6 @@ dependencies {
     implementation(projects.core.ui)
     implementation(projects.core.domain)
     implementation(projects.core.navigation)
-    implementation(libs.coil)
+    implementation(libs.coil.compose)
+    implementation(libs.coil.okhttp)
 }

--- a/features/reasons/src/main/java/com/depromeet/team5/feature/reasons/ImageDetailScreen.kt
+++ b/features/reasons/src/main/java/com/depromeet/team5/feature/reasons/ImageDetailScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import com.depromeet.team5.core.designsystem.foundation.HedgeColor
 import com.depromeet.team5.core.designsystem.foundation.HedgeIcon
 import com.depromeet.team5.core.designsystem.foundation.HedgeTypography

--- a/features/reasons/src/main/java/com/depromeet/team5/feature/reasons/ReasonScreen.kt
+++ b/features/reasons/src/main/java/com/depromeet/team5/feature/reasons/ReasonScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
@@ -52,7 +51,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
 import com.depromeet.team5.core.designsystem.component.HedgeButton
 import com.depromeet.team5.core.designsystem.component.HedgeToast
 import com.depromeet.team5.core.designsystem.component.HedgeToastState
@@ -64,6 +62,7 @@ import com.depromeet.team5.core.domain.model.OrderType
 import com.depromeet.team5.core.domain.monad.HedgeUiState
 import com.depromeet.team5.core.navigation.request.RequestViewModel
 import com.depromeet.team5.core.ui.HedgeModal
+import com.depromeet.team5.core.ui.component.HedgeCompanyLogo
 import com.depromeet.team5.core.ui.util.CurrencyUtil
 import com.depromeet.team5.feature.reasons.model.PrincipleAdherence
 import com.depromeet.team5.feature.reasons.model.RestrictionAttachment
@@ -101,6 +100,7 @@ fun ReasonRoute(
         }
         viewModel.initTradeInfo(
             TradeInfo(
+                logoUri = requestViewModel.companyLogoUrl,
                 stockName = requestViewModel.request.companyName,
                 orderType = requestViewModel.request.orderType,
                 price = requestViewModel.request.price.toLong(),
@@ -399,20 +399,11 @@ private fun TradeInfo(
             .padding(vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        tradeInfo.logoUri?.let {
-            AsyncImage(
-                model = it,
-                contentDescription = null,
-                modifier = Modifier
-                    .size(22.dp)
-                    .clip(CircleShape)
-            )
-        } ?: Icon(
-            imageVector = HedgeIcon.COMPANY_LOGO,
-            contentDescription = null,
-            tint = Color.Unspecified,
+        HedgeCompanyLogo(
+            logoUrl = tradeInfo.logoUri,
             modifier = Modifier
-                .size(22.dp),
+                .size(22.dp)
+                .clip(CircleShape)
         )
         Spacer(Modifier.size(12.dp))
         Text(

--- a/features/reasons/src/main/java/com/depromeet/team5/feature/reasons/RetrospectionDetailScreen.kt
+++ b/features/reasons/src/main/java/com/depromeet/team5/feature/reasons/RetrospectionDetailScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
 import com.depromeet.team5.core.designsystem.component.HedgeButton
 import com.depromeet.team5.core.designsystem.component.HedgeTopBar
 import com.depromeet.team5.core.designsystem.foundation.HedgeColor
@@ -66,6 +65,7 @@ import com.depromeet.team5.core.designsystem.foundation.HedgeTypography
 import com.depromeet.team5.core.domain.model.OrderType
 import com.depromeet.team5.core.domain.monad.HedgeUiState
 import com.depromeet.team5.core.ui.HedgeModal
+import com.depromeet.team5.core.ui.component.HedgeCompanyLogo
 import com.depromeet.team5.core.ui.component.HedgeLoadingScreen
 import com.depromeet.team5.core.ui.model.HedgeBadge
 import com.depromeet.team5.core.ui.util.CurrencyUtil
@@ -318,20 +318,11 @@ private fun TradeInfo(
             modifier = Modifier,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            thumbnail?.let {
-                AsyncImage(
-                    model = it,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(22.dp)
-                        .clip(CircleShape)
-                )
-            } ?: Icon(
-                imageVector = HedgeIcon.COMPANY_LOGO,
-                contentDescription = null,
-                tint = Color.Unspecified,
+            HedgeCompanyLogo(
+                logoUrl = thumbnail,
                 modifier = Modifier
-                    .size(22.dp),
+                    .size(22.dp)
+                    .clip(CircleShape)
             )
             Spacer(Modifier.size(8.dp))
             Text(

--- a/features/reasons/src/main/java/com/depromeet/team5/feature/reasons/ui/Thumbnail.kt
+++ b/features/reasons/src/main/java/com/depromeet/team5/feature/reasons/ui/Thumbnail.kt
@@ -38,9 +38,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import coil.compose.AsyncImage
-import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.compose.rememberAsyncImagePainter
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.depromeet.team5.core.designsystem.foundation.HedgeColor
 import com.depromeet.team5.core.designsystem.foundation.HedgeIcon
 import com.depromeet.team5.core.designsystem.foundation.HedgeTypography

--- a/features/retrospect/build.gradle.kts
+++ b/features/retrospect/build.gradle.kts
@@ -32,5 +32,6 @@ dependencies {
     implementation(projects.core.domain)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.okhttp)
 
 }

--- a/features/setting/build.gradle.kts
+++ b/features/setting/build.gradle.kts
@@ -29,4 +29,5 @@ dependencies {
     implementation(projects.core.domain)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.okhttp)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,6 @@ retrofitKotlinxSerializationConverter = "1.0.0"
 kotlinxSerialization = "2.1.0"
 kotlinxSerializationJson = "1.8.0"
 okhttp = "4.12.0"
-coil = "2.7.0"
 androidxComposeNavigation = "2.9.2"
 hiltNavigationCompose = "1.2.0"
 runtimeAnnotation = "1.9.0"
@@ -33,7 +32,7 @@ firebaseCrashlytics = "20.0.2"
 firebaseCrashlyticsPlugins = "3.0.6"
 googleService = "4.4.1"
 coroutineTest = "1.10.2"
-coilCompose = "3.3.0"
+coil = "3.3.0"
 jsoup = "1.21.2"
 kakao = "2.21.0"
 
@@ -62,7 +61,8 @@ androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime
 org-jsoup-jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 
 #coil
-coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 
 #kotlin
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
@@ -108,9 +108,6 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 #room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "room" }
 kotlin-serialization-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
-
-#coil
-coil = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 #kakao
 kakao-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao" }


### PR DESCRIPTION
이제 모든 화면 로고 다 잘 나옵니당..
안드 이슈였고, 해당 이슈가 발생한 시점이 공교롭게 서버 데이터가 꼬일 때였고, iOS도 안 된다해서 아주 큰 혼란이었네요

reason moudle 제외한 모든 로고들이 나오지 않고 있었습니다.
문제 : reason module은 coil 2를 사용하고 있었고 나머지는 coil3을 사용하고 있었음
분석 : coil2에서는 http/https url fetcher를 자동 지원했으나, coil3에서는 분리되어 coil-okHttp라이브러리까지 있어야 http/https 지원됨
해결 : coil3 + coil3-okhttp을 사용하는 것으로 해결